### PR TITLE
Fix docid generation and skip deletes on load failure

### DIFF
--- a/src/modules/rdb-helper.ts
+++ b/src/modules/rdb-helper.ts
@@ -905,23 +905,14 @@ export function init(
   ];
 }
 
-export function gen_docid(inp: string): number {
+export function gen_docid(inp: string): bigint {
   inp = inp.ljust(4, " ").rjust(8, "0");
-  const components: number[] = [];
+  let out = 0n;
   for (let i = 0; i < 8; i++) {
-    if (inp[i] === " ") components.push(36);
-    else components.push(parseInt(inp[i], 36));
+    const value = inp[i] === " " ? 36 : parseInt(inp[i], 36);
+    out = (out << 8n) | BigInt(value);
   }
-  return (
-    (components[0] << 64) |
-    (components[1] << 48) |
-    (components[2] << 32) |
-    components[3] |
-    (components[4] << 24) |
-    (components[5] << 16) |
-    (components[6] << 8) |
-    components[7]
-  );
+  return out;
 }
 
 export function mmjsonAt<T>(

--- a/src/modules/rdb-worker.ts
+++ b/src/modules/rdb-worker.ts
@@ -116,7 +116,8 @@ async function processEntry(payload: JobPayload): Promise<void> {
 
   if (jso === undefined) jso = await pipeline.load_data(payload, config);
   if (jso == null) {
-    getJob();
+    // Avoid deleting existing rows for transient load failures.
+    getJob(payload.entryId);
     return;
   }
 


### PR DESCRIPTION
- Use BigInt-based docid generation to avoid 32-bit truncation\n- Mark entries as processed when load_data returns null to avoid accidental deletes\n\nRefs #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates docid generation to BigInt and safeguards against accidental deletes on transient data load failures.
> 
> - Change `gen_docid` to return `bigint` and implement 8-byte packed generation using base-36 digits (in `rdb-helper.ts`)
> - On `load_data` returning `null`, skip DB mutations and call `getJob(payload.entryId)` to continue processing without deleting existing rows (in `rdb-worker.ts`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48058203463f7407f42c131d85930288975a41c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->