### PR TITLE
Handle directory-only patterns in walkPattern

### DIFF
--- a/src/modules/general.ts
+++ b/src/modules/general.ts
@@ -33,8 +33,24 @@ export async function walkPattern(
   pattern: string,
   options: WalkOptions = {}
 ): Promise<WalkFile[]> {
-  const base = path.dirname(pattern.substring(0, pattern.indexOf("*"))) + "/";
-  const matchObj = picomatch(pattern);
+  let matchPattern = pattern;
+  if (!pattern.includes("*")) {
+    try {
+      const stat = await fsp.stat(pattern);
+      if (stat.isDirectory()) {
+        matchPattern = path.join(pattern, "**/*");
+      }
+    } catch {
+      // Leave pattern as-is when it does not exist or is not accessible.
+    }
+  }
+
+  const starIndex = matchPattern.indexOf("*");
+  const base =
+    starIndex === -1
+      ? path.dirname(matchPattern) + "/"
+      : path.dirname(matchPattern.substring(0, starIndex)) + "/";
+  const matchObj = picomatch(matchPattern);
 
   const files: WalkFileWithPendingStats[] = [];
   const pattern_handler = function (pth: string): void {


### PR DESCRIPTION
- Treat directory paths as glob patterns so walkPattern returns files\n- Fixes EMDB scan when data path is a directory\n\nRefs #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves file walking by handling non-glob inputs and refining base calculation.
> 
> - If `pattern` has no `*` and is a directory, expand to `path.join(pattern, "**/*")`
> - Derive `base` from `matchPattern` whether or not it contains `*`; use `picomatch(matchPattern)`
> - Swallow `stat` errors for inaccessible/missing paths and leave `pattern` unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a13f3cf2c448fb3cc35d9d797389012714880e4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->