### PR TITLE
Quote identifiers in test DB setup and handle missing user

### DIFF
--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -40,7 +40,18 @@ function parseConnectionString(connString: string): DBConfig {
   if (userMatch) config.user = userMatch[1];
   const portMatch = connString.match(/port=(\d+)/);
   if (portMatch) config.port = portMatch[1];
+  if (!config.user) {
+    config.user = process.env.USER || process.env.USERNAME || "";
+  }
   return config;
+}
+
+function quoteIdent(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function quoteLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
 async function runPsql(
@@ -49,7 +60,11 @@ async function runPsql(
   command: string
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    const args = ["-U", dbConfig.user, "-p", dbConfig.port, "-d", database, "-t", "-A", "-c", command];
+    const args = [];
+    if (dbConfig.user) {
+      args.push("-U", dbConfig.user);
+    }
+    args.push("-p", dbConfig.port, "-d", database, "-t", "-A", "-c", command);
     const psql = spawn("psql", args, {
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, PGPASSWORD: process.env.PGPASSWORD || "" },
@@ -84,7 +99,17 @@ async function createDatabase(dbConfig: DBConfig, dbName: string): Promise<void>
   console.log(`==> Creating test database: ${dbName}...`);
   // Use current user to create database (like setup-test-db.sh does)
   const currentUser = process.env.USER || process.env.USERNAME || "postgres";
-  const args = ["-U", currentUser, "-p", dbConfig.port, "-d", "postgres", "-c", `CREATE DATABASE ${dbName} OWNER ${dbConfig.user};`];
+  const owner = dbConfig.user || currentUser;
+  const args = [
+    "-U",
+    currentUser,
+    "-p",
+    dbConfig.port,
+    "-d",
+    "postgres",
+    "-c",
+    `CREATE DATABASE ${quoteIdent(dbName)} OWNER ${quoteIdent(owner)};`,
+  ];
   
   return new Promise((resolve, reject) => {
     const psql = spawn("psql", args, {
@@ -117,7 +142,7 @@ async function dropDatabase(dbConfig: DBConfig, dbName: string): Promise<void> {
     "-p", dbConfig.port,
     "-d", "postgres",
     "-c",
-    `SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '${dbName}' AND pid <> pg_backend_pid();`
+    `SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = ${quoteLiteral(dbName)} AND pid <> pg_backend_pid();`
   ];
   
   await new Promise<void>((resolve) => {
@@ -132,7 +157,16 @@ async function dropDatabase(dbConfig: DBConfig, dbName: string): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 500));
   
   // Now drop the database
-  const args = ["-U", currentUser, "-p", dbConfig.port, "-d", "postgres", "-c", `DROP DATABASE IF EXISTS ${dbName};`];
+  const args = [
+    "-U",
+    currentUser,
+    "-p",
+    dbConfig.port,
+    "-d",
+    "postgres",
+    "-c",
+    `DROP DATABASE IF EXISTS ${quoteIdent(dbName)};`,
+  ];
   
   return new Promise((resolve, reject) => {
     const psql = spawn("psql", args, {
@@ -252,7 +286,7 @@ export async function testCommand(options: TestOptions): Promise<void> {
     const checkResult = await runPsql(
       dbConfig,
       "postgres",
-      `SELECT 1 FROM pg_database WHERE datname = '${testDbName}';`
+      `SELECT 1 FROM pg_database WHERE datname = ${quoteLiteral(testDbName)};`
     );
     dbExists = checkResult.stdout.trim().length > 0;
   } catch (error) {


### PR DESCRIPTION
- Quote database/user identifiers in test DB create/drop SQL\n- Avoid passing empty -U when user is missing\n\nRefs #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of the test DB setup.
> 
> - Add `quoteIdent`/`quoteLiteral` and use them in `CREATE DATABASE`, `DROP DATABASE`, connection-termination, and database-existence checks to properly quote identifiers/literals
> - `parseConnectionString` now falls back to `USER`/`USERNAME` when `user` is absent; `runPsql` omits `-U` if user is empty
> - Database owner now defaults to parsed user or current user; psql arg construction updated accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a3278c2b461f7245a4af5665eb710c54c1a9e09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->