### PR TITLE
refactor: Improve gemmi usage and unify CIF/mmJSON parsing

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -72,8 +72,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/23/60d1f411e2b5ee0a49b14f89261a8d1e594cfffa2863af00167dddab4ccf/gemmi-0.7.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/51/2779ccdf9305981a06b21a6b27e8547c948d85c41c76ff434192784a4c93/psycopg-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/62/513c80ad8bbb545e364f7737bf2492d34a4c05eef4f7b5c16428dc42260d/psycopg_binary-3.3.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl
@@ -81,6 +84,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/87/2a/a1810c8627b9ec8c57ec5ec325d306701ae7be50235e8fd81266e002a3cc/rich-14.3.1-py3-none-any.whl
@@ -270,6 +274,11 @@ packages:
   purls: []
   size: 12129203
   timestamp: 1720853576813
+- pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
+  name: iniconfig
+  version: 2.3.0
+  sha256: f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
   sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
   md5: b38117a3c920364aff79f870c984b4a3
@@ -646,6 +655,11 @@ packages:
   purls: []
   size: 3165399
   timestamp: 1762839186699
+- pypi: https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl
+  name: packaging
+  version: '26.0'
+  sha256: b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
   sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
   md5: 7a3bff861a6583f1889021facefc08b1
@@ -672,6 +686,17 @@ packages:
   purls: []
   size: 450960
   timestamp: 1754665235234
+- pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+  name: pluggy
+  version: 1.6.0
+  sha256: e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+  requires_dist:
+  - pre-commit ; extra == 'dev'
+  - tox ; extra == 'dev'
+  - pytest ; extra == 'testing'
+  - pytest-benchmark ; extra == 'testing'
+  - coverage ; extra == 'testing'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.10-hd526058_1.conda
   sha256: a8a17d3ff9eb99b04eb3df6b37e0385397a4ba8c21fab9838080a0069ad23e8f
   md5: 90bc8b42401e5a0c22c37e80404df6ff
@@ -795,6 +820,26 @@ packages:
   requires_dist:
   - colorama>=0.4.6 ; extra == 'windows-terminal'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+  name: pytest
+  version: 9.0.2
+  sha256: 711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b
+  requires_dist:
+  - colorama>=0.4 ; sys_platform == 'win32'
+  - exceptiongroup>=1 ; python_full_version < '3.11'
+  - iniconfig>=1.0.1
+  - packaging>=22
+  - pluggy>=1.5,<2
+  - pygments>=2.7.2
+  - tomli>=1 ; python_full_version < '3.11'
+  - argcomplete ; extra == 'dev'
+  - attrs>=19.2 ; extra == 'dev'
+  - hypothesis>=3.56 ; extra == 'dev'
+  - mock ; extra == 'dev'
+  - requests ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  - xmlschema ; extra == 'dev'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_1_cpython.conda
   build_number: 1
   sha256: 39898d24769a848c057ab861052e50bdc266310a7509efa3514b840e85a2ae98

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,6 +12,7 @@ format = "ruff format src/mine2"
 typecheck = "ty check src/mine2"
 check = { depends-on = ["lint", "format-check", "typecheck"] }
 format-check = "ruff format --check src/mine2"
+test = "PYTHONPATH=src pytest tests -v"
 
 # Run
 mine2 = "PYTHONPATH=src python -m mine2"
@@ -38,6 +39,7 @@ pyyaml = ">=6.0.0"
 tqdm = ">=4.66.0"
 ruff = ">=0.9.0"
 ty = "*"
+pytest = ">=8.0.0"
 
 # Default environment variables (override with .env file)
 [activation.env]

--- a/src/mine2/parsers/__init__.py
+++ b/src/mine2/parsers/__init__.py
@@ -1,6 +1,20 @@
 """Data parsers for CIF and mmJSON formats."""
 
-from mine2.parsers.cif import parse_cif, parse_cif_file
-from mine2.parsers.mmjson import load_mmjson, load_mmjson_file
+from mine2.parsers.cif import (
+    parse_cif,
+    parse_cif_file,
+    parse_mmjson,
+    parse_mmjson_file,
+    parse_mmjson_file_blocks,
+)
+from mine2.parsers.mmjson import merge_data, normalize_column_name
 
-__all__ = ["parse_cif", "parse_cif_file", "load_mmjson", "load_mmjson_file"]
+__all__ = [
+    "parse_cif",
+    "parse_cif_file",
+    "parse_mmjson",
+    "parse_mmjson_file",
+    "parse_mmjson_file_blocks",
+    "merge_data",
+    "normalize_column_name",
+]

--- a/src/mine2/parsers/cif.py
+++ b/src/mine2/parsers/cif.py
@@ -1,10 +1,90 @@
 """CIF parser using gemmi library."""
 
-import gzip
+import logging
 from pathlib import Path
 from typing import Any
 
 import gemmi
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_cif_value(value: Any) -> Any:
+    """Normalize CIF special values.
+
+    gemmi converts: '?' -> None, '.' -> False
+    We normalize both to None for database insertion.
+    """
+    if value is False:
+        return None
+    return value
+
+
+def parse_block(block: gemmi.cif.Block) -> dict[str, Any]:
+    """Parse a single gemmi Block into row-oriented dict."""
+    result: dict[str, Any] = {}
+    result["_block_name"] = block.name
+    logger.debug("Parsing block: %s", block.name)
+
+    for cat_name in block.get_mmcif_category_names():
+        # '_entry.' -> 'entry'
+        category = cat_name.strip("_").rstrip(".")
+        col_data = block.get_mmcif_category(cat_name)
+
+        if not col_data:
+            continue
+
+        # Convert column-oriented to row-oriented, normalizing values
+        keys = list(col_data.keys())
+        n_rows = len(col_data[keys[0]]) if keys else 0
+        rows = [
+            {k: _normalize_cif_value(col_data[k][i]) for k in keys}
+            for i in range(n_rows)
+        ]
+
+        if category in result:
+            result[category].extend(rows)
+        else:
+            result[category] = rows
+
+        logger.debug("  Category %s: %d rows, %d columns", category, n_rows, len(keys))
+
+    return result
+
+
+def parse_cif_document(doc: gemmi.cif.Document) -> dict[str, Any]:
+    """Parse gemmi Document into a dictionary.
+
+    Uses gemmi's get_mmcif_category() for efficient parsing.
+    Returns a dict where keys are category names (e.g., 'entry', 'atom_site')
+    and values are lists of rows (each row is a dict of column -> value).
+
+    For CIF files with multiple blocks, data from all blocks is merged.
+    Metadata:
+    - `_block_name`: Name of the last block (for backward compatibility)
+    - `_block_names`: List of all block names (when multiple blocks exist)
+    """
+    result: dict[str, Any] = {}
+    block_names: list[str] = []
+
+    for block in doc:
+        block_data = parse_block(block)
+        # Merge block data into result
+        for key, value in block_data.items():
+            if key == "_block_name":
+                block_names.append(value)
+            elif key in result and isinstance(value, list):
+                result[key].extend(value)
+            else:
+                result[key] = value
+
+    # Store block name(s)
+    if block_names:
+        result["_block_name"] = block_names[-1]  # Last block for compatibility
+        if len(block_names) > 1:
+            result["_block_names"] = block_names
+
+    return result
 
 
 def parse_cif(content: str) -> dict[str, Any]:
@@ -14,63 +94,13 @@ def parse_cif(content: str) -> dict[str, Any]:
     and values are lists of rows (each row is a dict of column -> value).
     """
     doc = gemmi.cif.read_string(content)
-
-    result: dict[str, Any] = {}
-
-    for block in doc:
-        block_name = block.name
-
-        for item in block:
-            if item.loop is not None:
-                # Loop (table) data
-                loop = item.loop
-                tags = [
-                    tag.split(".")[-1] for tag in loop.tags
-                ]  # Remove category prefix
-                category = (
-                    loop.tags[0].split(".")[0].lstrip("_") if loop.tags else "unknown"
-                )
-
-                rows = []
-                width = loop.width()
-                for row_idx in range(loop.length()):
-                    row_data = {}
-                    for col_idx, tag in enumerate(tags):
-                        value = loop.values[row_idx * width + col_idx]
-                        # Convert CIF special values
-                        if value in (".", "?"):
-                            value = None
-                        row_data[tag] = value
-                    rows.append(row_data)
-
-                if category in result:
-                    result[category].extend(rows)
-                else:
-                    result[category] = rows
-
-            elif item.pair is not None:
-                # Single key-value pair
-                tag, value = item.pair
-                category = tag.split(".")[0].lstrip("_")
-                column = tag.split(".")[-1]
-
-                if value in (".", "?"):
-                    value = None
-
-                if category not in result:
-                    result[category] = [{}]
-                if len(result[category]) == 0:
-                    result[category].append({})
-                result[category][0][column] = value
-
-        # Store block name for reference
-        result["_block_name"] = block_name
-
-    return result
+    return parse_cif_document(doc)
 
 
-def parse_cif_file(filepath: Path) -> dict[str, Any]:
+def parse_cif_file(filepath: Path | str) -> dict[str, Any]:
     """Parse a CIF file (supports gzip compression).
+
+    Uses gemmi.cif.read() which handles .gz files automatically.
 
     Args:
         filepath: Path to the CIF file (.cif or .cif.gz)
@@ -78,43 +108,75 @@ def parse_cif_file(filepath: Path) -> dict[str, Any]:
     Returns:
         Parsed CIF data as dictionary
     """
-    if filepath.suffix == ".gz" or str(filepath).endswith(".cif.gz"):
-        with gzip.open(filepath, "rt", encoding="utf-8") as f:
-            content = f.read()
-    else:
-        with open(filepath, encoding="utf-8") as f:
-            content = f.read()
-
-    return parse_cif(content)
+    logger.debug("Parsing CIF file: %s", filepath)
+    doc = gemmi.cif.read(str(filepath))
+    logger.debug("CIF document has %d block(s)", len(doc))
+    return parse_cif_document(doc)
 
 
-def cif_to_mmjson_format(cif_data: dict[str, Any]) -> dict[str, Any]:
-    """Convert CIF dict to mmJSON-like format.
+# =============================================================================
+# mmJSON support (using gemmi.cif.read_mmjson)
+# =============================================================================
 
-    mmJSON format uses arrays of values instead of list of dicts:
-    {
-        "category": {
-            "column1": ["val1", "val2"],
-            "column2": ["val1", "val2"]
-        }
-    }
+
+def parse_mmjson_document(doc: gemmi.cif.Document) -> dict[str, Any]:
+    """Parse gemmi Document (from mmJSON) into a dictionary.
+
+    Same output format as parse_cif_document - row-oriented dict.
+    Uses the first block by default (use parse_mmjson_blocks for multi-block).
     """
-    result: dict[str, Any] = {}
+    if len(doc) == 0:
+        return {}
+    return parse_block(doc[0])
 
-    for category, rows in cif_data.items():
-        if category.startswith("_"):
-            continue
-        if not rows:
-            continue
 
-        # Convert list of dicts to dict of lists
-        columns: dict[str, list] = {}
-        for row in rows:
-            for key, value in row.items():
-                if key not in columns:
-                    columns[key] = []
-                columns[key].append(value)
+def parse_mmjson_blocks(doc: gemmi.cif.Document) -> dict[str, dict[str, Any]]:
+    """Parse all blocks from mmJSON Document.
 
-        result[category] = columns
+    Returns dict mapping block names to their row-oriented data.
+    Useful for PRD files with multiple data blocks.
+    """
+    return {block.name: parse_block(block) for block in doc}
 
-    return result
+
+def parse_mmjson(content: str) -> dict[str, Any]:
+    """Parse mmJSON content string into a dictionary.
+
+    Returns row-oriented dict (same format as parse_cif).
+    """
+    doc = gemmi.cif.read_mmjson_string(content)
+    return parse_mmjson_document(doc)
+
+
+def parse_mmjson_file(filepath: Path | str) -> dict[str, Any]:
+    """Parse an mmJSON file (supports gzip compression).
+
+    Uses gemmi.cif.read_mmjson() which handles .gz files automatically.
+
+    Args:
+        filepath: Path to the mmJSON file (.json or .json.gz)
+
+    Returns:
+        Parsed data as row-oriented dictionary
+    """
+    logger.debug("Parsing mmJSON file: %s", filepath)
+    doc = gemmi.cif.read_mmjson(str(filepath))
+    logger.debug("mmJSON document has %d block(s)", len(doc))
+    return parse_mmjson_document(doc)
+
+
+def parse_mmjson_file_blocks(filepath: Path | str) -> dict[str, dict[str, Any]]:
+    """Parse an mmJSON file with multiple data blocks.
+
+    Useful for PRD files that contain both PRD and PRDCC blocks.
+
+    Args:
+        filepath: Path to the mmJSON file (.json or .json.gz)
+
+    Returns:
+        Dict mapping block names to their row-oriented data
+    """
+    logger.debug("Parsing mmJSON file (multi-block): %s", filepath)
+    doc = gemmi.cif.read_mmjson(str(filepath))
+    logger.debug("mmJSON document has %d block(s)", len(doc))
+    return parse_mmjson_blocks(doc)

--- a/src/mine2/parsers/mmjson.py
+++ b/src/mine2/parsers/mmjson.py
@@ -1,9 +1,10 @@
-"""mmJSON parser for PDBj data files."""
+"""mmJSON utilities for PDBj data files.
 
-import gzip
-import json
+Note: Parsing is now handled by parsers/cif.py using gemmi.
+This module provides utility functions for column name normalization and data merging.
+"""
+
 import re
-from pathlib import Path
 from typing import Any
 
 
@@ -19,144 +20,56 @@ def normalize_column_name(name: str) -> str:
     return re.sub(r"\[(\d+)\]", r"\1", name)
 
 
-def load_mmjson(content: str) -> dict[str, Any]:
-    """Parse mmJSON content string.
-
-    mmJSON format:
-    {
-        "category_name": {
-            "column1": ["value1", "value2", ...],
-            "column2": ["value1", "value2", ...]
-        }
-    }
-
-    Each category contains columns as arrays of equal length,
-    representing rows of data.
-    """
-    return json.loads(content)
-
-
-def load_mmjson_file(filepath: Path) -> dict[str, Any]:
-    """Load mmJSON file (supports gzip compression).
-
-    mmJSON files from PDBj have structure:
-    {
-        "data_<ENTRY_ID>": {
-            "category": {...},
-            ...
-        }
-    }
-
-    This function extracts the inner data block automatically.
-
-    Args:
-        filepath: Path to the mmJSON file (.json or .json.gz)
-
-    Returns:
-        Parsed mmJSON data (the inner data block)
-    """
-    if filepath.suffix == ".gz" or str(filepath).endswith(".json.gz"):
-        with gzip.open(filepath, "rt", encoding="utf-8") as f:
-            content = f.read()
-    else:
-        with open(filepath, encoding="utf-8") as f:
-            content = f.read()
-
-    raw = load_mmjson(content)
-
-    # Extract the data block (data_<ENTRY_ID>)
-    # The file typically has one key like "data_100D"
-    for key, value in raw.items():
-        if key.startswith("data_") and isinstance(value, dict):
-            return value
-
-    # Fallback: return as-is if no data_ block found
-    return raw
-
-
-def get_rows(data: dict[str, Any], category: str) -> list[dict[str, Any]]:
-    """Convert mmJSON category to list of row dicts.
-
-    Args:
-        data: mmJSON data
-        category: Category name to extract
-
-    Returns:
-        List of dicts, one per row
-    """
-    if category not in data:
-        return []
-
-    cat_data = data[category]
-    if not cat_data:
-        return []
-
-    # Get all column names
-    columns = list(cat_data.keys())
-    if not columns:
-        return []
-
-    # Get number of rows from first column
-    num_rows = len(cat_data[columns[0]])
-
-    # Build rows
-    rows = []
-    for i in range(num_rows):
-        row = {}
-        for col in columns:
-            values = cat_data[col]
-            row[col] = values[i] if i < len(values) else None
-        rows.append(row)
-
-    return rows
-
-
-def get_value(data: dict[str, Any], category: str, column: str, row: int = 0) -> Any:
-    """Get a single value from mmJSON data.
-
-    Args:
-        data: mmJSON data
-        category: Category name
-        column: Column name
-        row: Row index (default 0)
-
-    Returns:
-        The value, or None if not found
-    """
-    if category not in data:
-        return None
-
-    cat_data = data[category]
-    if column not in cat_data:
-        return None
-
-    values = cat_data[column]
-    if row >= len(values):
-        return None
-
-    return values[row]
-
-
-def merge_mmjson(base: dict[str, Any], plus: dict[str, Any]) -> dict[str, Any]:
-    """Merge two mmJSON files (base + plus data).
+def merge_data(base: dict[str, Any], plus: dict[str, Any]) -> dict[str, Any]:
+    """Merge two row-oriented data dicts (base + plus data).
 
     The 'plus' data is typically additional annotations from PDBj.
-    Plus data takes precedence for overlapping categories.
+    Plus data takes precedence for overlapping categories/columns.
+
+    For each category:
+    - If only in base: keep as-is
+    - If only in plus: add to result
+    - If in both: merge rows by index (plus columns take precedence)
+
+    Note:
+        If a category exists in both base and plus with different row counts,
+        the result will have max(base_rows, plus_rows) rows. Missing rows
+        are treated as empty dicts (no columns added from the shorter side).
 
     Args:
-        base: Base mmJSON data
-        plus: Additional mmJSON data to merge
+        base: Base row-oriented data
+        plus: Additional row-oriented data to merge
 
     Returns:
-        Merged mmJSON data
+        Merged row-oriented data
     """
-    result = dict(base)
+    result: dict[str, Any] = {}
 
-    for category, cat_data in plus.items():
-        if category in result:
-            # Merge columns - plus takes precedence
-            result[category] = {**result[category], **cat_data}
+    # Get all categories from both
+    all_categories = set(base.keys()) | set(plus.keys())
+
+    for category in all_categories:
+        if category.startswith("_"):
+            # Metadata like _block_name - plus takes precedence
+            result[category] = plus.get(category, base.get(category))
+            continue
+
+        base_rows = base.get(category, [])
+        plus_rows = plus.get(category, [])
+
+        if not base_rows:
+            result[category] = plus_rows
+        elif not plus_rows:
+            result[category] = base_rows
         else:
-            result[category] = cat_data
+            # Merge rows by index
+            merged_rows = []
+            max_len = max(len(base_rows), len(plus_rows))
+            for i in range(max_len):
+                base_row = base_rows[i] if i < len(base_rows) else {}
+                plus_row = plus_rows[i] if i < len(plus_rows) else {}
+                # Plus takes precedence
+                merged_rows.append({**base_row, **plus_row})
+            result[category] = merged_rows
 
     return result

--- a/src/mine2/pipelines/cc.py
+++ b/src/mine2/pipelines/cc.py
@@ -8,8 +8,9 @@ from rich.console import Console
 
 from mine2.config import PipelineConfig, Settings
 from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, bulk_upsert
-from mine2.parsers.mmjson import get_rows, load_mmjson_file, normalize_column_name
-from mine2.pipelines.base import BasePipeline
+from mine2.parsers.cif import parse_mmjson_file
+from mine2.parsers.mmjson import normalize_column_name
+from mine2.pipelines.base import BasePipeline, transform_category
 
 console = Console()
 
@@ -38,7 +39,7 @@ class CcPipeline(BasePipeline):
     ) -> LoaderResult:
         """Process a single chemical component."""
         try:
-            data = load_mmjson_file(job.filepath)
+            data = parse_mmjson_file(job.filepath)
             rows_inserted = 0
 
             # Load all tables from schema
@@ -79,54 +80,9 @@ class CcPipeline(BasePipeline):
         comp_id: str,
         pk_col: str,
     ) -> list[dict]:
-        """Transform a category's data.
-
-        Args:
-            data: mmJSON data
-            table: Table definition from schema
-            comp_id: Chemical component ID
-            pk_col: Primary key column name (comp_id)
-        """
-        rows = get_rows(data, table.name)
-        if not rows:
-            return []
-
-        # Get column names from schema (preserving order)
-        schema_columns = [col_name for col_name, _ in table.columns]
-        valid_columns = set(schema_columns)
-
-        # First pass: collect all columns that appear in any row
-        used_columns = {pk_col}
-        for row in rows:
-            for col_name in row:
-                normalized = normalize_column_name(col_name)
-                if normalized in valid_columns:
-                    used_columns.add(normalized)
-
-        # Determine final column order (pk first, then schema order)
-        final_columns = [pk_col] + [
-            c for c in schema_columns if c in used_columns and c != pk_col
-        ]
-
-        # Second pass: build rows with consistent columns
-        result = []
-        for row in rows:
-            # Normalize all column names
-            normalized_row = {}
-            for col_name, value in row.items():
-                normalized = normalize_column_name(col_name)
-                if normalized in valid_columns:
-                    normalized_row[normalized] = value
-
-            # Build row with all final_columns (None for missing)
-            transformed_row = {pk_col: comp_id}
-            for col in final_columns:
-                if col == pk_col:
-                    continue
-                transformed_row[col] = normalized_row.get(col)
-
-            result.append(transformed_row)
-        return result
+        """Transform a category's data."""
+        rows = data.get(table.name, [])
+        return transform_category(rows, table, comp_id, pk_col, normalize_column_name)
 
 
 def run(

--- a/src/mine2/pipelines/ccmodel.py
+++ b/src/mine2/pipelines/ccmodel.py
@@ -7,8 +7,9 @@ from typing import Any
 from rich.console import Console
 
 from mine2.config import PipelineConfig, Settings
-from mine2.db.loader import Job, LoaderResult, SchemaDef, bulk_upsert
-from mine2.parsers.mmjson import get_rows, load_mmjson_file, normalize_column_name
+from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, bulk_upsert
+from mine2.parsers.cif import parse_mmjson_file
+from mine2.parsers.mmjson import normalize_column_name
 from mine2.pipelines.base import BasePipeline, transform_category
 
 console = Console()
@@ -38,7 +39,7 @@ class CcmodelPipeline(BasePipeline):
     ) -> LoaderResult:
         """Process a single component model."""
         try:
-            data = load_mmjson_file(job.filepath)
+            data = parse_mmjson_file(job.filepath)
             rows_inserted = 0
 
             # Generate and load brief_summary
@@ -93,7 +94,7 @@ class CcmodelPipeline(BasePipeline):
         self, data: dict[str, Any], model_id: str
     ) -> list[dict]:
         """Generate brief_summary from pdbx_chem_comp_model data."""
-        rows = get_rows(data, "pdbx_chem_comp_model")
+        rows = data.get("pdbx_chem_comp_model", [])
         if not rows:
             return [{"model_id": model_id}]
 
@@ -110,12 +111,12 @@ class CcmodelPipeline(BasePipeline):
     def _transform_category(
         self,
         data: dict[str, Any],
-        table: Any,
+        table: TableDef,
         model_id: str,
         pk_col: str,
     ) -> list[dict]:
         """Transform a category's data."""
-        rows = get_rows(data, table.name)
+        rows = data.get(table.name, [])
         return transform_category(rows, table, model_id, pk_col, normalize_column_name)
 
 

--- a/src/mine2/pipelines/contacts.py
+++ b/src/mine2/pipelines/contacts.py
@@ -76,8 +76,13 @@ class ContactsPipeline(BasePipeline):
                     "list",
                     columns,
                     [tuple(r[c] for c in columns) for r in contact_rows],
-                    ["pdbid", "label_asym_id_1", "label_asym_id_2",
-                     "label_seq_id_1", "label_seq_id_2"],
+                    [
+                        "pdbid",
+                        "label_asym_id_1",
+                        "label_asym_id_2",
+                        "label_seq_id_1",
+                        "label_seq_id_2",
+                    ],
                 )
                 rows_inserted += inserted
 
@@ -104,9 +109,7 @@ class ContactsPipeline(BasePipeline):
             with open(filepath, encoding="utf-8") as f:
                 return json.load(f)
 
-    def _transform_contacts(
-        self, data: list[list[Any]], pdbid: str
-    ) -> list[dict]:
+    def _transform_contacts(self, data: list[list[Any]], pdbid: str) -> list[dict]:
         """Transform contact records to database rows.
 
         Contact record format (array):
@@ -125,16 +128,18 @@ class ContactsPipeline(BasePipeline):
             if len(record) < 8:
                 continue
 
-            result.append({
-                "pdbid": pdbid,
-                "label_asym_id_1": record[1],
-                "label_asym_id_2": record[2],
-                "label_seq_id_1": record[3],
-                "label_seq_id_2": record[4],
-                "label_comp_id_1": record[5],
-                "label_comp_id_2": record[6],
-                "distance": record[7],
-            })
+            result.append(
+                {
+                    "pdbid": pdbid,
+                    "label_asym_id_1": record[1],
+                    "label_asym_id_2": record[2],
+                    "label_seq_id_1": record[3],
+                    "label_seq_id_2": record[4],
+                    "label_comp_id_1": record[5],
+                    "label_comp_id_2": record[6],
+                    "distance": record[7],
+                }
+            )
 
         return result
 

--- a/src/mine2/pipelines/pdbj.py
+++ b/src/mine2/pipelines/pdbj.py
@@ -8,13 +8,9 @@ from rich.console import Console
 
 from mine2.config import PipelineConfig, Settings
 from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, bulk_upsert
-from mine2.parsers.mmjson import (
-    get_rows,
-    load_mmjson_file,
-    merge_mmjson,
-    normalize_column_name,
-)
-from mine2.pipelines.base import BasePipeline
+from mine2.parsers.cif import parse_mmjson_file
+from mine2.parsers.mmjson import merge_data, normalize_column_name
+from mine2.pipelines.base import BasePipeline, transform_category
 
 console = Console()
 
@@ -89,14 +85,14 @@ class PdbjPipeline(BasePipeline):
     ) -> LoaderResult:
         """Process a single PDB entry."""
         try:
-            # Load main data
-            data = load_mmjson_file(job.filepath)
+            # Load main data (row-oriented)
+            data = parse_mmjson_file(job.filepath)
 
             # Merge with plus data if available
             plus_path = job.extra.get("plus_path")
             if plus_path:
-                plus_data = load_mmjson_file(plus_path)
-                data = merge_mmjson(data, plus_data)
+                plus_data = parse_mmjson_file(plus_path)
+                data = merge_data(data, plus_data)
 
             # Transform and load
             rows_inserted = 0
@@ -160,7 +156,7 @@ class PdbjPipeline(BasePipeline):
 
     def _transform_entry(self, data: dict[str, Any], entry_id: str) -> list[dict]:
         """Transform entry data."""
-        rows = get_rows(data, "entry")
+        rows = data.get("entry", [])
         if not rows:
             # Fallback: create minimal entry with both PK columns
             return [{"pdbid": entry_id, "id": entry_id.upper()}]
@@ -181,51 +177,9 @@ class PdbjPipeline(BasePipeline):
         table: TableDef,
         entry_id: str,
     ) -> list[dict]:
-        """Transform a category's data.
-
-        Args:
-            data: mmJSON data
-            table: Table definition from schema
-            entry_id: PDB entry ID
-        """
-        rows = get_rows(data, table.name)
-        if not rows:
-            return []
-
-        # Get column names from schema (preserving order)
-        schema_columns = [col_name for col_name, _ in table.columns]
-        valid_columns = set(schema_columns)
-
-        # First pass: collect all columns that appear in any row
-        used_columns = {"pdbid"}  # Always include pdbid
-        for row in rows:
-            for col_name in row:
-                normalized = normalize_column_name(col_name)
-                if normalized in valid_columns:
-                    used_columns.add(normalized)
-
-        # Determine final column order (pdbid first, then schema order)
-        final_columns = ["pdbid"] + [c for c in schema_columns if c in used_columns]
-
-        # Second pass: build rows with consistent columns
-        result = []
-        for row in rows:
-            # Normalize all column names
-            normalized_row = {}
-            for col_name, value in row.items():
-                normalized = normalize_column_name(col_name)
-                if normalized in valid_columns:
-                    normalized_row[normalized] = value
-
-            # Build row with all final_columns (None for missing)
-            transformed_row = {"pdbid": entry_id}
-            for col in final_columns:
-                if col == "pdbid":
-                    continue
-                transformed_row[col] = normalized_row.get(col)
-
-            result.append(transformed_row)
-        return result
+        """Transform a category's data."""
+        rows = data.get(table.name, [])
+        return transform_category(rows, table, entry_id, "pdbid", normalize_column_name)
 
 
 def run(

--- a/src/mine2/pipelines/prd.py
+++ b/src/mine2/pipelines/prd.py
@@ -1,6 +1,5 @@
 """PRD (BIRD) pipeline - Biologically Interesting Reference Dictionary."""
 
-import gzip
 import traceback
 from pathlib import Path
 from typing import Any
@@ -8,8 +7,9 @@ from typing import Any
 from rich.console import Console
 
 from mine2.config import PipelineConfig, Settings
-from mine2.db.loader import Job, LoaderResult, SchemaDef, bulk_upsert
-from mine2.parsers.mmjson import get_rows, load_mmjson, normalize_column_name
+from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, bulk_upsert
+from mine2.parsers.cif import parse_mmjson_file_blocks
+from mine2.parsers.mmjson import normalize_column_name
 from mine2.pipelines.base import BasePipeline, transform_category
 
 console = Console()
@@ -53,22 +53,17 @@ class PrdPipeline(BasePipeline):
     ) -> LoaderResult:
         """Process a single PRD entry."""
         try:
-            # Load raw JSON (PRD files have two data blocks, can't use load_mmjson_file)
-            if str(job.filepath).endswith(".json.gz"):
-                with gzip.open(job.filepath, "rt", encoding="utf-8") as f:
-                    raw_data = load_mmjson(f.read())
-            else:
-                with open(job.filepath, encoding="utf-8") as f:
-                    raw_data = load_mmjson(f.read())
+            # Load all data blocks (PRD files have two: PRD and PRDCC)
+            all_blocks = parse_mmjson_file_blocks(job.filepath)
 
             rows_inserted = 0
 
             # PRD files have two data blocks:
-            # - data_PRD_XXXXXX (pdbx_reference_* categories)
-            # - data_PRDCC_XXXXXX (chem_comp_* categories)
-            prd_data = raw_data.get(f"data_{job.entry_id}", {})
+            # - PRD_XXXXXX (pdbx_reference_* categories)
+            # - PRDCC_XXXXXX (chem_comp_* categories)
+            prd_data = all_blocks.get(job.entry_id, {})
             prdcc_id = job.entry_id.replace("PRD_", "PRDCC_")
-            prdcc_data = raw_data.get(f"data_{prdcc_id}", {})
+            prdcc_data = all_blocks.get(prdcc_id, {})
 
             # Generate and load brief_summary from pdbx_reference_molecule
             brief_rows = self._generate_brief_summary(prd_data, job.entry_id)
@@ -126,7 +121,7 @@ class PrdPipeline(BasePipeline):
 
     def _generate_brief_summary(self, data: dict[str, Any], prd_id: str) -> list[dict]:
         """Generate brief_summary from pdbx_reference_molecule data."""
-        rows = get_rows(data, "pdbx_reference_molecule")
+        rows = data.get("pdbx_reference_molecule", [])
         if not rows:
             return []
 
@@ -145,12 +140,12 @@ class PrdPipeline(BasePipeline):
     def _transform_category(
         self,
         data: dict[str, Any],
-        table: Any,
+        table: TableDef,
         prd_id: str,
         pk_col: str,
     ) -> list[dict]:
         """Transform a category's data."""
-        rows = get_rows(data, table.name)
+        rows = data.get(table.name, [])
         return transform_category(rows, table, prd_id, pk_col, normalize_column_name)
 
 

--- a/src/mine2/pipelines/vrpt.py
+++ b/src/mine2/pipelines/vrpt.py
@@ -4,10 +4,11 @@ import traceback
 from pathlib import Path
 from typing import Any
 
+import gemmi
 from rich.console import Console
 
 from mine2.config import PipelineConfig, Settings
-from mine2.db.loader import Job, LoaderResult, SchemaDef, bulk_upsert
+from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, bulk_upsert
 from mine2.parsers.cif import parse_cif_file
 from mine2.pipelines.base import BasePipeline, transform_category
 
@@ -20,23 +21,37 @@ class VrptPipeline(BasePipeline):
     Uses gemmi to parse CIF files directly - no JSON conversion needed.
 
     Directory structure: data/<2-3char>/<pdbid>/<pdbid>_validation.cif.gz
+
+    Note: file_pattern is not defined because this pipeline uses gemmi.CifWalk
+    with custom filtering (_is_validation_file) instead of rglob pattern matching.
+    CifWalk recursively finds all CIF files and handles .cif.gz automatically.
     """
 
     name = "vrpt"
-    file_pattern = "*_validation.cif.gz"
+    # file_pattern intentionally omitted - using gemmi.CifWalk instead
 
-    def extract_entry_id(self, filepath: Path) -> str:
+    def extract_entry_id(self, filepath: Path | str) -> str:
         """Extract PDB ID from validation report filename."""
         # Files are named like: 100d_validation.cif.gz
-        name = filepath.stem
+        name = Path(filepath).name
+        # Remove .gz suffix if present
+        if name.endswith(".gz"):
+            name = name[:-3]
+        # Remove .cif suffix
         if name.endswith(".cif"):
             name = name[:-4]
+        # Remove _validation suffix
         if name.endswith("_validation"):
             name = name[:-11]
         return name.lower()
 
+    def _is_validation_file(self, filepath: str) -> bool:
+        """Check if filepath is a validation report file."""
+        name = Path(filepath).name.lower()
+        return "_validation.cif" in name
+
     def find_jobs(self, limit: int | None = None) -> list[Job]:
-        """Find validation report files.
+        """Find validation report files using gemmi.CifWalk.
 
         Handles nested directory structure:
         data/<2-3char>/<pdbid>/<pdbid>_validation.cif.gz
@@ -48,21 +63,15 @@ class VrptPipeline(BasePipeline):
             return []
 
         jobs = []
-        # Iterate through hash directories (2-3 char subdirs) for efficiency
-        for hash_dir in sorted(data_dir.iterdir()):
-            if not hash_dir.is_dir():
+        for filepath in gemmi.CifWalk(str(data_dir)):
+            if not self._is_validation_file(filepath):
                 continue
-            # Iterate through entry directories
-            for entry_dir in sorted(hash_dir.iterdir()):
-                if not entry_dir.is_dir():
-                    continue
-                # Find validation files in entry directory
-                for filepath in entry_dir.glob(self.file_pattern):
-                    entry_id = self.extract_entry_id(filepath)
-                    jobs.append(Job(entry_id=entry_id, filepath=filepath))
 
-                    if limit and len(jobs) >= limit:
-                        return jobs
+            entry_id = self.extract_entry_id(filepath)
+            jobs.append(Job(entry_id=entry_id, filepath=Path(filepath)))
+
+            if limit and len(jobs) >= limit:
+                break
 
         return jobs
 
@@ -133,7 +142,7 @@ class VrptPipeline(BasePipeline):
     def _transform_category(
         self,
         data: dict[str, Any],
-        table: Any,
+        table: TableDef,
         pdbid: str,
         pk_col: str,
     ) -> list[dict]:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for mine2updater-ng."""

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,224 @@
+"""Tests for parsers module."""
+
+import pytest
+
+from mine2.parsers.cif import (
+    _normalize_cif_value,
+    parse_block,
+    parse_cif,
+    parse_cif_document,
+    parse_mmjson,
+    parse_mmjson_blocks,
+)
+from mine2.parsers.mmjson import merge_data, normalize_column_name
+
+
+class TestNormalizeCifValue:
+    """Tests for _normalize_cif_value function."""
+
+    def test_false_to_none(self) -> None:
+        """CIF '.' (inapplicable) is converted to False by gemmi, then to None."""
+        assert _normalize_cif_value(False) is None
+
+    def test_none_unchanged(self) -> None:
+        """CIF '?' (unknown) is converted to None by gemmi, stays None."""
+        assert _normalize_cif_value(None) is None
+
+    def test_string_unchanged(self) -> None:
+        """Regular string values are unchanged."""
+        assert _normalize_cif_value("hello") == "hello"
+
+    def test_empty_string_unchanged(self) -> None:
+        """Empty strings are unchanged."""
+        assert _normalize_cif_value("") == ""
+
+    def test_numeric_string_unchanged(self) -> None:
+        """Numeric strings are unchanged (gemmi returns all values as strings)."""
+        assert _normalize_cif_value("42") == "42"
+        assert _normalize_cif_value("3.14") == "3.14"
+
+
+class TestNormalizeColumnName:
+    """Tests for normalize_column_name function."""
+
+    def test_single_bracket(self) -> None:
+        """Single bracket notation is normalized."""
+        assert normalize_column_name("column[0]") == "column0"
+
+    def test_double_bracket(self) -> None:
+        """Double bracket notation is normalized."""
+        assert normalize_column_name("fract_transf_matrix[1][1]") == "fract_transf_matrix11"
+
+    def test_no_bracket(self) -> None:
+        """Column without brackets is unchanged."""
+        assert normalize_column_name("simple_column") == "simple_column"
+
+    def test_multiple_brackets(self) -> None:
+        """Multiple brackets are all normalized."""
+        assert normalize_column_name("a[1][2][3]") == "a123"
+
+
+class TestMergeData:
+    """Tests for merge_data function."""
+
+    def test_non_overlapping_categories(self) -> None:
+        """Categories unique to each dict are preserved."""
+        base = {"cat1": [{"a": 1}]}
+        plus = {"cat2": [{"b": 2}]}
+        result = merge_data(base, plus)
+
+        assert "cat1" in result
+        assert "cat2" in result
+        assert result["cat1"] == [{"a": 1}]
+        assert result["cat2"] == [{"b": 2}]
+
+    def test_overlapping_categories_merge_columns(self) -> None:
+        """Overlapping categories merge row columns, plus takes precedence."""
+        base = {"entry": [{"id": "TEST", "title": "Base Title"}]}
+        plus = {"entry": [{"id": "PLUS", "keywords": "extra"}]}
+        result = merge_data(base, plus)
+
+        assert result["entry"] == [{"id": "PLUS", "title": "Base Title", "keywords": "extra"}]
+
+    def test_different_row_counts(self) -> None:
+        """Categories with different row counts use max rows."""
+        base = {"atoms": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}
+        plus = {"atoms": [{"x": "1.0"}]}  # Only 1 row
+        result = merge_data(base, plus)
+
+        assert len(result["atoms"]) == 3
+        assert result["atoms"][0] == {"id": "1", "x": "1.0"}
+        assert result["atoms"][1] == {"id": "2"}
+        assert result["atoms"][2] == {"id": "3"}
+
+    def test_metadata_plus_takes_precedence(self) -> None:
+        """Metadata keys (starting with _) from plus take precedence."""
+        base = {"_block_name": "BASE", "entry": [{"id": "1"}]}
+        plus = {"_block_name": "PLUS"}
+        result = merge_data(base, plus)
+
+        assert result["_block_name"] == "PLUS"
+
+    def test_empty_base(self) -> None:
+        """Empty base returns plus data."""
+        base: dict = {}
+        plus = {"entry": [{"id": "TEST"}]}
+        result = merge_data(base, plus)
+
+        assert result == {"entry": [{"id": "TEST"}]}
+
+    def test_empty_plus(self) -> None:
+        """Empty plus returns base data."""
+        base = {"entry": [{"id": "TEST"}]}
+        plus: dict = {}
+        result = merge_data(base, plus)
+
+        assert result == {"entry": [{"id": "TEST"}]}
+
+
+class TestParseCif:
+    """Tests for CIF parsing functions."""
+
+    def test_parse_cif_simple(self) -> None:
+        """Parse simple CIF content."""
+        cif_content = """data_TEST
+_entry.id TEST
+"""
+        result = parse_cif(cif_content)
+
+        assert result["_block_name"] == "TEST"
+        assert result["entry"] == [{"id": "TEST"}]
+
+    def test_parse_cif_loop(self) -> None:
+        """Parse CIF with loop (table) data."""
+        cif_content = """data_TEST
+loop_
+_atom_site.id
+_atom_site.type_symbol
+1 C
+2 N
+"""
+        result = parse_cif(cif_content)
+
+        assert result["atom_site"] == [
+            {"id": "1", "type_symbol": "C"},
+            {"id": "2", "type_symbol": "N"},
+        ]
+
+    def test_parse_cif_special_values(self) -> None:
+        """CIF special values ? and . are converted to None."""
+        cif_content = """data_TEST
+loop_
+_test.id
+_test.val1
+_test.val2
+1 ? .
+"""
+        result = parse_cif(cif_content)
+
+        assert result["test"] == [{"id": "1", "val1": None, "val2": None}]
+
+
+class TestParseMmjson:
+    """Tests for mmJSON parsing functions."""
+
+    def test_parse_mmjson_simple(self) -> None:
+        """Parse simple mmJSON content."""
+        mmjson = """
+{
+  "data_TEST": {
+    "entry": {
+      "id": ["TEST"]
+    }
+  }
+}
+"""
+        result = parse_mmjson(mmjson)
+
+        assert result["_block_name"] == "TEST"
+        assert result["entry"] == [{"id": "TEST"}]
+
+    def test_parse_mmjson_multiple_rows(self) -> None:
+        """Parse mmJSON with multiple rows."""
+        mmjson = """
+{
+  "data_TEST": {
+    "atom_site": {
+      "id": ["1", "2"],
+      "type_symbol": ["C", "N"]
+    }
+  }
+}
+"""
+        result = parse_mmjson(mmjson)
+
+        assert result["atom_site"] == [
+            {"id": "1", "type_symbol": "C"},
+            {"id": "2", "type_symbol": "N"},
+        ]
+
+    def test_parse_mmjson_blocks_multiple(self) -> None:
+        """Parse mmJSON with multiple data blocks."""
+        import gemmi
+
+        mmjson = """
+{
+  "data_PRD_000001": {
+    "pdbx_reference_molecule": {
+      "name": ["Test Molecule"]
+    }
+  },
+  "data_PRDCC_000001": {
+    "chem_comp": {
+      "id": ["ATP"]
+    }
+  }
+}
+"""
+        doc = gemmi.cif.read_mmjson_string(mmjson)
+        blocks = parse_mmjson_blocks(doc)
+
+        assert "PRD_000001" in blocks
+        assert "PRDCC_000001" in blocks
+        assert blocks["PRD_000001"]["pdbx_reference_molecule"] == [{"name": "Test Molecule"}]
+        assert blocks["PRDCC_000001"]["chem_comp"] == [{"id": "ATP"}]


### PR DESCRIPTION
## Summary
- Use `gemmi.cif.read()` and `read_mmjson()` for automatic gzip handling
- Use `gemmi.CifWalk` for file traversal in vrpt pipeline
- Use `get_mmcif_category()` for efficient category extraction
- Unify CIF and mmJSON parsing through common row-oriented format
- Deduplicate `_transform_category` by using shared `transform_category` from base.py
- Add debug logging to parsers
- Add 21 unit tests for parser functions
- Fix type annotations (`table: Any` -> `TableDef`)

## Changes
- `parsers/cif.py`: Unified CIF/mmJSON parsing with gemmi, added logging
- `parsers/mmjson.py`: Simplified to `normalize_column_name` and `merge_data` only
- `pipelines/*.py`: Use shared `transform_category`, fix type annotations
- `tests/test_parsers.py`: New unit tests for parser functions

## Test plan
- [x] All 21 unit tests pass
- [x] Lint checks pass
- [x] Type check passes (known psycopg LiteralString issue)