### PR TITLE
docs: Update documentation for gemmi-unified parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ PDBj (Protein Data Bank Japan) のデータを PostgreSQL にロードする CLI
 - **Database**: PostgreSQL 12+ (psycopg3)
 - **CLI**: Typer + Rich
 - **Config**: Pydantic
-- **Parser**: gemmi (CIF), json (mmJSON)
+- **Parser**: gemmi (CIF and mmJSON unified)
 
 ## Quick Start
 
@@ -29,8 +29,8 @@ src/mine2/
 │   ├── connection.py   # Connection pool
 │   └── loader.py       # Parallel loader (ProcessPoolExecutor)
 ├── parsers/
-│   ├── mmjson.py       # mmJSON parser + normalize_column_name()
-│   └── cif.py          # CIF parser (gemmi)
+│   ├── cif.py          # Unified parser (CIF + mmJSON via gemmi)
+│   └── mmjson.py       # Utilities: normalize_column_name(), merge_data()
 ├── pipelines/
 │   ├── base.py         # BasePipeline + transform_category()
 │   ├── pdbj.py         # Main PDB data (mmJSON + plus)
@@ -40,6 +40,7 @@ src/mine2/
 │   ├── vrpt.py         # Validation reports (CIF)
 │   └── contacts.py     # Contact data (custom JSON)
 schemas/                # YAML schema definitions
+tests/                  # Unit tests (pytest)
 docs/                   # Architecture docs
 ```
 
@@ -47,14 +48,28 @@ docs/                   # Architecture docs
 
 | Pipeline | Format | Notes |
 |----------|--------|-------|
-| pdbj | mmJSON | Merges noatom + plus files |
+| pdbj | mmJSON | Merges noatom + plus files via merge_data() |
 | cc | mmJSON | Chemical component dictionary |
 | ccmodel | mmJSON | Component 3D models |
 | prd | mmJSON | Has TWO data blocks (PRD + PRDCC) |
-| vrpt | CIF | Uses gemmi, nested directory structure |
+| vrpt | CIF | Uses gemmi.CifWalk for nested directory structure |
 | contacts | JSON | Array format, not mmJSON |
 
 ## Key Patterns
+
+### Unified Parsing (gemmi)
+Both CIF and mmJSON are parsed via gemmi, returning row-oriented dicts:
+```python
+from mine2.parsers.cif import parse_cif_file, parse_mmjson_file
+
+# CIF files (supports .cif.gz)
+data = parse_cif_file(filepath)
+
+# mmJSON files (supports .json.gz)
+data = parse_mmjson_file(filepath)
+
+# Both return: {"category": [{"col": "val", ...}, ...], "_block_name": "..."}
+```
 
 ### Column Name Normalization
 mmJSON uses `column[1][2]` → schema uses `column12`
@@ -78,7 +93,8 @@ rows = transform_category(rows, table, pk_value, pk_col, normalize_column_name)
 pixi run lint          # ruff check
 pixi run format        # ruff format
 pixi run typecheck     # ty check
-pixi run check         # all checks
+pixi run test          # pytest
+pixi run check         # all checks (lint, format, typecheck)
 ```
 
 ## Database

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ pixi run format
 # Type check
 pixi run typecheck
 
+# Run tests
+pixi run test
+
 # All checks
 pixi run check
 ```
@@ -151,8 +154,8 @@ mine2updater-ng/
 │   │   ├── connection.py # Connection pool
 │   │   └── loader.py     # Parallel data loader
 │   ├── parsers/
-│   │   ├── mmjson.py    # mmJSON parser
-│   │   └── cif.py       # CIF parser (gemmi)
+│   │   ├── cif.py       # Unified parser (CIF + mmJSON via gemmi)
+│   │   └── mmjson.py    # Utilities (normalize_column_name, merge_data)
 │   └── pipelines/
 │       ├── base.py      # Base pipeline class
 │       ├── pdbj.py      # PDB structure data
@@ -162,6 +165,7 @@ mine2updater-ng/
 │       ├── vrpt.py      # Validation reports
 │       └── contacts.py  # Contact data
 ├── schemas/             # Database schema definitions
+├── tests/               # Unit tests (pytest)
 ├── scripts/             # Utility scripts
 ├── config.yml           # Production config
 ├── config.test.yml      # Test config

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,33 +39,34 @@ Pydantic-based configuration with:
 
 ### Parsers
 
-#### mmJSON Parser (`parsers/mmjson.py`)
+Both CIF and mmJSON formats are parsed through gemmi, providing a unified row-oriented output format.
 
-Parses PDBj's mmJSON format:
-```json
-{
-  "data_100D": {
-    "category_name": {
-      "column1": ["val1", "val2"],
-      "column2": ["val1", "val2"]
-    }
-  }
-}
+#### Unified Parser (`parsers/cif.py`)
+
+Uses gemmi library to parse both CIF and mmJSON files:
+
+```python
+from mine2.parsers.cif import parse_cif_file, parse_mmjson_file
+
+# CIF files (supports .cif.gz automatically)
+data = parse_cif_file(filepath)
+
+# mmJSON files (supports .json.gz automatically)
+data = parse_mmjson_file(filepath)
+
+# Both return: {"category": [{"col": "val", ...}, ...], "_block_name": "..."}
 ```
 
 Key functions:
-- `load_mmjson_file()`: Load and extract data block
-- `get_rows()`: Convert column arrays to row dicts
+- `parse_cif_file()`: Parse CIF files via `gemmi.cif.read()`
+- `parse_mmjson_file()`: Parse mmJSON files via `gemmi.cif.read_mmjson()`
+- `parse_mmjson_file_blocks()`: Parse multi-block mmJSON (for PRD files)
+
+#### Utilities (`parsers/mmjson.py`)
+
+Helper functions for data processing:
 - `normalize_column_name()`: Convert `col[1][2]` to `col12`
-
-#### CIF Parser (`parsers/cif.py`)
-
-Uses gemmi library to parse CIF files directly:
-```python
-doc = gemmi.cif.read_string(content)
-```
-
-Returns dict of category -> list of row dicts.
+- `merge_data()`: Merge row-oriented data dicts (for pdbj noatom + plus)
 
 ### Database Layer
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -50,8 +50,9 @@ from typing import Any
 from rich.console import Console
 
 from mine2.config import PipelineConfig, Settings
-from mine2.db.loader import Job, LoaderResult, SchemaDef, bulk_upsert
-from mine2.parsers.mmjson import get_rows, load_mmjson_file
+from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, bulk_upsert
+from mine2.parsers.cif import parse_mmjson_file
+from mine2.parsers.mmjson import normalize_column_name
 from mine2.pipelines.base import BasePipeline, transform_category
 
 console = Console()
@@ -78,7 +79,7 @@ class MydataPipeline(BasePipeline):
     ) -> LoaderResult:
         """Process a single entry."""
         try:
-            data = load_mmjson_file(job.filepath)
+            data = parse_mmjson_file(job.filepath)
             rows_inserted = 0
 
             # Load brief_summary
@@ -100,9 +101,9 @@ class MydataPipeline(BasePipeline):
                 if table.name == "brief_summary":
                     continue
 
-                rows = get_rows(data, table.name)
+                rows = data.get(table.name, [])
                 category_rows = transform_category(
-                    rows, table, job.entry_id, schema_def.primary_key
+                    rows, table, job.entry_id, schema_def.primary_key, normalize_column_name
                 )
                 if category_rows:
                     columns = list(category_rows[0].keys())
@@ -134,7 +135,7 @@ class MydataPipeline(BasePipeline):
         self, data: dict[str, Any], entry_id: str
     ) -> list[dict]:
         """Generate brief_summary from data."""
-        rows = get_rows(data, "main_category")
+        rows = data.get("main_category", [])
         if not rows:
             return [{"entry_id": entry_id}]
 
@@ -168,10 +169,11 @@ Edit `src/mine2/cli.py` to add the pipeline name to `PIPELINES` list.
 Use for most PDBj data:
 
 ```python
-from mine2.parsers.mmjson import get_rows, load_mmjson_file, normalize_column_name
+from mine2.parsers.cif import parse_mmjson_file
+from mine2.parsers.mmjson import normalize_column_name
 
-data = load_mmjson_file(filepath)
-rows = get_rows(data, "category_name")
+data = parse_mmjson_file(filepath)  # Row-oriented dict
+rows = data.get("category_name", [])
 ```
 
 ### CIF Data
@@ -181,7 +183,7 @@ Use for validation reports:
 ```python
 from mine2.parsers.cif import parse_cif_file
 
-data = parse_cif_file(filepath)  # Returns dict of category -> rows
+data = parse_cif_file(filepath)  # Row-oriented dict (same format as mmJSON)
 rows = data.get("category_name", [])
 ```
 
@@ -202,13 +204,13 @@ with gzip.open(filepath, "rt") as f:
 For files with multiple data blocks (like PRD):
 
 ```python
-from mine2.parsers.mmjson import load_mmjson
+from mine2.parsers.cif import parse_mmjson_file_blocks
 
-with gzip.open(filepath, "rt") as f:
-    raw = load_mmjson(f.read())
+blocks = parse_mmjson_file_blocks(filepath)
+# Returns: {"PRD_000001": {...}, "PRDCC_000001": {...}}
 
-block1 = raw.get(f"data_{entry_id}", {})
-block2 = raw.get(f"data_{other_id}", {})
+prd_data = blocks.get(f"PRD_{entry_id}", {})
+prdcc_data = blocks.get(f"PRDCC_{entry_id}", {})
 ```
 
 ### Custom File Discovery


### PR DESCRIPTION
## Summary
Update documentation to reflect the gemmi-unified parsing refactor from PR #11.

## Changes
- **CLAUDE.md**: Update parser description, add unified parsing pattern example
- **README.md**: Update parsers section, add tests directory to structure
- **docs/architecture.md**: Rewrite parsers section for unified approach
- **docs/pipelines.md**: Update code examples to use new API (`parse_mmjson_file`, `parse_cif_file`)

## Test plan
- [x] Documentation reviewed for accuracy
- [x] Code examples match current implementation