### PR TITLE
feat: Add prd-cif pipeline for single CIF file processing

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,6 +18,9 @@ pipelines:
   prd:
     deffile: ${CWD}schemas/prd.def.yml
     data: /mnt/c/pdb/pdbj/pdbjplus/data/prd/mmjson/
+  prd-cif:
+    deffile: ${CWD}schemas/prd.def.yml
+    data: /mnt/c/pdb/data/bird/prd/
   ccmodel:
     deffile: ${CWD}schemas/ccmodel.def.yml
     data: /mnt/c/pdb/pdbj/pdbjplus/data/ccmodel/mmjson/

--- a/src/mine2/commands/sync.py
+++ b/src/mine2/commands/sync.py
@@ -47,6 +47,11 @@ SYNC_TARGETS: dict[str, dict] = {
         "dest": "data/prd/",
         "options": ["-avz", "--delete"],
     },
+    "prd-cif": {
+        "source": "rsync.pdbj.org::ftp_data/bird/prd/",
+        "dest": "data/bird/prd/",
+        "options": ["-avz"],
+    },
     "vrpt": {
         # Fixed: use include/exclude pattern to avoid timeout
         "source": "rsync.pdbj.org::ftp_data/validation_reports/",

--- a/src/mine2/commands/update.py
+++ b/src/mine2/commands/update.py
@@ -18,6 +18,7 @@ AVAILABLE_PIPELINES = [
     "ccmodel",
     "ccmodel-cif",
     "prd",
+    "prd-cif",
     "vrpt",
     "contacts",
 ]
@@ -99,6 +100,7 @@ def _get_pipeline_runner(pipeline_name: str) -> tuple[str, str]:
     special_cases = {
         "cc-cif": ("cc", "run_cif"),
         "ccmodel-cif": ("ccmodel", "run_cif"),
+        "prd-cif": ("prd", "run_cif"),
     }
     if pipeline_name in special_cases:
         return special_cases[pipeline_name]

--- a/src/mine2/pipelines/prd.py
+++ b/src/mine2/pipelines/prd.py
@@ -1,18 +1,172 @@
 """PRD (BIRD) pipeline - Biologically Interesting Reference Dictionary."""
 
 import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
+import gemmi
 from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from tqdm import tqdm
 
 from mine2.config import PipelineConfig, Settings
 from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, bulk_upsert
-from mine2.parsers.cif import parse_mmjson_file_blocks
+from mine2.parsers.cif import parse_block, parse_mmjson_file_blocks
 from mine2.parsers.mmjson import normalize_column_name
 from mine2.pipelines.base import BasePipeline, transform_category
 
 console = Console()
+
+# Tables that come from the PRDCC data block (used by both pipelines)
+PRDCC_TABLES = {
+    "chem_comp",
+    "chem_comp_atom",
+    "chem_comp_bond",
+    "pdbx_chem_comp_descriptor",
+    "pdbx_chem_comp_identifier",
+}
+
+
+# =============================================================================
+# Worker function for parallel CIF processing (must be at module level)
+# =============================================================================
+
+
+def _process_prd_cif_chunk(
+    prd_cif_path: str,
+    prdcc_cif_path: str | None,
+    start_idx: int,
+    end_idx: int,
+    schema_def: SchemaDef,
+    conninfo: str,
+) -> list[LoaderResult]:
+    """Process a chunk of blocks from the PRD CIF files.
+
+    Args:
+        prd_cif_path: Path to prd-all.cif.gz
+        prdcc_cif_path: Path to prdcc-all.cif.gz (may be None)
+        start_idx: Starting block index (inclusive)
+        end_idx: Ending block index (exclusive)
+        schema_def: Schema definition
+        conninfo: Database connection string
+
+    Returns:
+        List of LoaderResults for each processed block
+    """
+    # Read PRD CIF
+    prd_doc = gemmi.cif.read(prd_cif_path)
+
+    # Build PRDCC lookup dictionary if file exists
+    prdcc_lookup: dict[str, gemmi.cif.Block] = {}
+    if prdcc_cif_path:
+        prdcc_doc = gemmi.cif.read(prdcc_cif_path)
+        for block in prdcc_doc:
+            prdcc_lookup[block.name] = block
+
+    results = []
+
+    for i in range(start_idx, end_idx):
+        prd_block = prd_doc[i]
+        prd_id = prd_block.name  # e.g., PRD_000001
+
+        try:
+            # Parse PRD block data
+            prd_data = parse_block(prd_block)
+
+            # Find corresponding PRDCC block
+            prdcc_id = prd_id.replace("PRD_", "PRDCC_")
+            prdcc_block = prdcc_lookup.get(prdcc_id)
+            prdcc_data = parse_block(prdcc_block) if prdcc_block else {}
+
+            rows_inserted = 0
+
+            # Generate and load brief_summary
+            brief_rows = _generate_brief_summary_prd(prd_data, prd_id)
+            if brief_rows:
+                columns = list(brief_rows[0].keys())
+                inserted, _ = bulk_upsert(
+                    conninfo,
+                    schema_def.schema_name,
+                    "brief_summary",
+                    columns,
+                    [tuple(r[c] for c in columns) for r in brief_rows],
+                    ["prd_id"],
+                )
+                rows_inserted += inserted
+
+            # Load other tables
+            for table in schema_def.tables:
+                if table.name == "brief_summary":
+                    continue
+
+                # Determine which data block to use
+                if table.name in PRDCC_TABLES:
+                    data = prdcc_data
+                else:
+                    data = prd_data
+
+                rows = data.get(table.name, [])
+                # CIF uses plain column names, no normalization needed
+                category_rows = transform_category(
+                    rows, table, prd_id, schema_def.primary_key, None
+                )
+                if category_rows:
+                    columns = list(category_rows[0].keys())
+                    inserted, _ = bulk_upsert(
+                        conninfo,
+                        schema_def.schema_name,
+                        table.name,
+                        columns,
+                        [tuple(r[c] for c in columns) for r in category_rows],
+                        table.primary_key,
+                    )
+                    rows_inserted += inserted
+
+            results.append(
+                LoaderResult(
+                    entry_id=prd_id,
+                    success=True,
+                    rows_inserted=rows_inserted,
+                )
+            )
+
+        except Exception as e:
+            error_msg = f"{e}\n{traceback.format_exc()}"
+            results.append(
+                LoaderResult(
+                    entry_id=prd_id,
+                    success=False,
+                    error=error_msg,
+                )
+            )
+
+    return results
+
+
+def _generate_brief_summary_prd(data: dict[str, Any], prd_id: str) -> list[dict]:
+    """Generate brief_summary from pdbx_reference_molecule data."""
+    rows = data.get("pdbx_reference_molecule", [])
+    if not rows:
+        return []
+
+    result = []
+    for row in rows:
+        result.append(
+            {
+                "prd_id": prd_id,
+                "name": row.get("name"),
+                "formula": row.get("formula"),
+                "description": row.get("description"),
+            }
+        )
+    return result
 
 
 class PrdPipeline(BasePipeline):
@@ -25,15 +179,6 @@ class PrdPipeline(BasePipeline):
 
     name = "prd"
     file_pattern = "*.json.gz"
-
-    # Tables that come from the PRDCC data block
-    PRDCC_TABLES = {
-        "chem_comp",
-        "chem_comp_atom",
-        "chem_comp_bond",
-        "pdbx_chem_comp_descriptor",
-        "pdbx_chem_comp_identifier",
-    }
 
     def extract_entry_id(self, filepath: Path) -> str:
         """Extract PRD ID from filename.
@@ -85,7 +230,7 @@ class PrdPipeline(BasePipeline):
                     continue  # Already handled
 
                 # Determine which data block to use
-                if table.name in self.PRDCC_TABLES:
+                if table.name in PRDCC_TABLES:
                     data = prdcc_data
                 else:
                     data = prd_data
@@ -149,12 +294,296 @@ class PrdPipeline(BasePipeline):
         return transform_category(rows, table, prd_id, pk_col, normalize_column_name)
 
 
+class PrdCifPipeline:
+    """Pipeline for loading PRD data from CIF files.
+
+    Uses prd-all.cif.gz and prdcc-all.cif.gz which contain all entries.
+    Each data block represents one PRD/PRDCC entry.
+    """
+
+    name = "prd-cif"
+
+    def __init__(
+        self,
+        settings: Settings,
+        config: PipelineConfig,
+        schema_def: SchemaDef,
+    ):
+        self.settings = settings
+        self.config = config
+        self.schema_def = schema_def
+
+    def run(self, limit: int | None = None) -> list[LoaderResult]:
+        """Run the pipeline with parallel processing."""
+        prd_path, prdcc_path = self._find_cif_files()
+        if not prd_path:
+            return []
+        console.print(f"  PRD CIF: {prd_path}")
+        if prdcc_path:
+            console.print(f"  PRDCC CIF: {prdcc_path}")
+        else:
+            console.print(
+                "  [yellow]PRDCC CIF not found, skipping PRDCC tables[/yellow]"
+            )
+
+        # Get block count from PRD file
+        console.print("  Counting PRD entries...")
+        doc = gemmi.cif.read(str(prd_path))
+        total_blocks = len(doc)
+        del doc  # Release memory, workers will re-read
+        console.print(f"  Found {total_blocks} PRD entries")
+
+        if limit:
+            total_blocks = min(total_blocks, limit)
+            console.print(f"  Processing {total_blocks} (limited)")
+
+        max_workers = self.settings.rdb.nworkers
+        conninfo = self.settings.rdb.constring
+
+        # For small counts, process sequentially
+        if total_blocks <= 10 or max_workers == 1:
+            return self._run_sequential(prd_path, prdcc_path, total_blocks, conninfo)
+
+        return self._run_parallel(
+            prd_path, prdcc_path, total_blocks, max_workers, conninfo
+        )
+
+    def _run_sequential(
+        self,
+        prd_path: Path,
+        prdcc_path: Path | None,
+        total_blocks: int,
+        conninfo: str,
+    ) -> list[LoaderResult]:
+        """Run sequentially for small datasets."""
+        prd_doc = gemmi.cif.read(str(prd_path))
+
+        # Build PRDCC lookup
+        prdcc_lookup: dict[str, gemmi.cif.Block] = {}
+        if prdcc_path:
+            prdcc_doc = gemmi.cif.read(str(prdcc_path))
+            for block in prdcc_doc:
+                prdcc_lookup[block.name] = block
+
+        results: list[LoaderResult] = []
+
+        for i in tqdm(range(total_blocks), desc="Processing"):
+            prd_block = prd_doc[i]
+            result = self._process_block(prd_block, prdcc_lookup, conninfo)
+            results.append(result)
+
+        self._print_summary(results)
+        return results
+
+    def _run_parallel(
+        self,
+        prd_path: Path,
+        prdcc_path: Path | None,
+        total_blocks: int,
+        max_workers: int,
+        conninfo: str,
+    ) -> list[LoaderResult]:
+        """Run with parallel processing using chunks."""
+        chunk_size = max(100, total_blocks // max_workers)
+        chunks = []
+        for start in range(0, total_blocks, chunk_size):
+            end = min(start + chunk_size, total_blocks)
+            chunks.append((start, end))
+
+        console.print(
+            f"[bold]Processing {total_blocks} PRD entries "
+            f"with {max_workers} workers ({len(chunks)} chunks)...[/bold]"
+        )
+
+        results: list[LoaderResult] = []
+
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            future_to_chunk = {
+                executor.submit(
+                    _process_prd_cif_chunk,
+                    str(prd_path),
+                    str(prdcc_path) if prdcc_path else None,
+                    start,
+                    end,
+                    self.schema_def,
+                    conninfo,
+                ): (start, end)
+                for start, end in chunks
+            }
+
+            with Progress(
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                TaskProgressColumn(),
+                TimeElapsedColumn(),
+                console=console,
+            ) as progress:
+                task = progress.add_task("Processing", total=len(chunks))
+
+                for future in as_completed(future_to_chunk):
+                    chunk = future_to_chunk[future]
+                    try:
+                        chunk_results = future.result()
+                        results.extend(chunk_results)
+                    except Exception as e:
+                        start, end = chunk
+                        for idx in range(start, end):
+                            results.append(
+                                LoaderResult(
+                                    entry_id=f"block_{idx}",
+                                    success=False,
+                                    error=str(e),
+                                )
+                            )
+                    progress.advance(task)
+
+        self._print_summary(results)
+        return results
+
+    def _find_cif_files(self) -> tuple[Path | None, Path | None]:
+        """Find prd-all.cif.gz and prdcc-all.cif.gz files."""
+        data_dir = Path(self.config.data)
+
+        if not data_dir.exists():
+            console.print(f"  [red]Data directory not found: {data_dir}[/red]")
+            return None, None
+
+        # Find PRD file
+        prd_path = self._find_file(data_dir, "prd-all.cif.gz")
+        if not prd_path:
+            console.print(f"  [red]prd-all.cif.gz not found in: {data_dir}[/red]")
+            return None, None
+
+        # Find PRDCC file (optional)
+        prdcc_path = self._find_file(data_dir, "prdcc-all.cif.gz")
+
+        return prd_path, prdcc_path
+
+    def _find_file(self, data_dir: Path, filename: str) -> Path | None:
+        """Find a CIF file, handling rsync quirks."""
+        # Try direct path
+        direct_path = data_dir / filename
+        if direct_path.is_file():
+            return direct_path
+
+        # Handle rsync quirk (filename becomes directory)
+        nested_path = data_dir / filename / filename
+        if nested_path.is_file():
+            return nested_path
+
+        # Search recursively
+        for path in data_dir.rglob(filename):
+            if path.is_file():
+                return path
+
+        return None
+
+    def _process_block(
+        self,
+        prd_block: gemmi.cif.Block,
+        prdcc_lookup: dict[str, gemmi.cif.Block],
+        conninfo: str,
+    ) -> LoaderResult:
+        """Process a single PRD block."""
+        prd_id = prd_block.name
+        try:
+            # Parse PRD block data
+            prd_data = parse_block(prd_block)
+
+            # Find corresponding PRDCC block
+            prdcc_id = prd_id.replace("PRD_", "PRDCC_")
+            prdcc_block = prdcc_lookup.get(prdcc_id)
+            prdcc_data = parse_block(prdcc_block) if prdcc_block else {}
+
+            rows_inserted = 0
+
+            # Generate and load brief_summary
+            brief_rows = _generate_brief_summary_prd(prd_data, prd_id)
+            if brief_rows:
+                columns = list(brief_rows[0].keys())
+                inserted, _ = bulk_upsert(
+                    conninfo,
+                    self.schema_def.schema_name,
+                    "brief_summary",
+                    columns,
+                    [tuple(r[c] for c in columns) for r in brief_rows],
+                    ["prd_id"],
+                )
+                rows_inserted += inserted
+
+            # Load other tables
+            for table in self.schema_def.tables:
+                if table.name == "brief_summary":
+                    continue
+
+                # Determine which data block to use
+                if table.name in PRDCC_TABLES:
+                    data = prdcc_data
+                else:
+                    data = prd_data
+
+                rows = data.get(table.name, [])
+                category_rows = transform_category(
+                    rows, table, prd_id, self.schema_def.primary_key, None
+                )
+                if category_rows:
+                    columns = list(category_rows[0].keys())
+                    inserted, _ = bulk_upsert(
+                        conninfo,
+                        self.schema_def.schema_name,
+                        table.name,
+                        columns,
+                        [tuple(r[c] for c in columns) for r in category_rows],
+                        table.primary_key,
+                    )
+                    rows_inserted += inserted
+
+            return LoaderResult(
+                entry_id=prd_id,
+                success=True,
+                rows_inserted=rows_inserted,
+            )
+
+        except Exception as e:
+            error_msg = f"{e}\n{traceback.format_exc()}"
+            return LoaderResult(
+                entry_id=prd_id,
+                success=False,
+                error=error_msg,
+            )
+
+    def _print_summary(self, results: list[LoaderResult]) -> None:
+        """Print processing summary."""
+        success_count = sum(1 for r in results if r.success)
+        fail_count = len(results) - success_count
+
+        console.print(f"\n[green]✓ {success_count} succeeded[/green]", end="")
+        if fail_count > 0:
+            console.print(f", [red]✗ {fail_count} failed[/red]")
+            for r in results[:5]:
+                if not r.success and r.error:
+                    console.print(f"  [dim]{r.entry_id}: {r.error}[/dim]")
+        else:
+            console.print()
+
+
 def run(
     settings: Settings,
     config: PipelineConfig,
     schema_def: SchemaDef,
     limit: int | None = None,
 ) -> list[LoaderResult]:
-    """Run the prd pipeline."""
+    """Run the prd pipeline (mmJSON version)."""
     pipeline = PrdPipeline(settings, config, schema_def)
+    return pipeline.run(limit)
+
+
+def run_cif(
+    settings: Settings,
+    config: PipelineConfig,
+    schema_def: SchemaDef,
+    limit: int | None = None,
+) -> list[LoaderResult]:
+    """Run the prd-cif pipeline (CIF version)."""
+    pipeline = PrdCifPipeline(settings, config, schema_def)
     return pipeline.run(limit)

--- a/tests/test_prd_cif.py
+++ b/tests/test_prd_cif.py
@@ -1,0 +1,454 @@
+"""Tests for prd-cif pipeline."""
+
+import gzip
+from pathlib import Path
+
+import gemmi
+import pytest
+
+from mine2.config import PipelineConfig, RdbConfig, Settings
+from mine2.db.loader import LoaderResult, SchemaDef, TableDef
+from mine2.pipelines.prd import (
+    PRDCC_TABLES,
+    PrdCifPipeline,
+    _generate_brief_summary_prd,
+    _process_prd_cif_chunk,
+)
+
+
+def create_test_prd_cif_content(entries: list[dict]) -> str:
+    """Create PRD CIF content string with the given entries.
+
+    Args:
+        entries: List of dicts with 'id', 'name', 'formula', 'description' keys
+
+    Returns:
+        CIF format string
+    """
+    blocks = []
+    for entry in entries:
+        prd_id = entry["id"]  # e.g., PRD_000001
+        name = entry.get("name", "Test Compound")
+        # Quote strings with spaces
+        if " " in name:
+            name = f"'{name}'"
+        formula = entry.get("formula", "C10H20")
+        description = entry.get("description", "Test description")
+        if " " in description:
+            description = f"'{description}'"
+        blocks.append(f"""data_{prd_id}
+_pdbx_reference_molecule.prd_id {prd_id}
+_pdbx_reference_molecule.name {name}
+_pdbx_reference_molecule.formula {formula}
+_pdbx_reference_molecule.description {description}
+""")
+    return "\n".join(blocks)
+
+
+def create_test_prdcc_cif_content(entries: list[dict]) -> str:
+    """Create PRDCC CIF content string with the given entries.
+
+    Args:
+        entries: List of dicts with 'id', 'formula', 'name' keys
+
+    Returns:
+        CIF format string
+    """
+    blocks = []
+    for entry in entries:
+        prdcc_id = entry["id"]  # e.g., PRDCC_000001
+        comp_id = entry.get("comp_id", "UNK")
+        formula = entry.get("formula", "C10H20")
+        name = entry.get("name", "Unknown")
+        if " " in name:
+            name = f"'{name}'"
+        blocks.append(f"""data_{prdcc_id}
+_chem_comp.id {comp_id}
+_chem_comp.formula {formula}
+_chem_comp.name {name}
+""")
+    return "\n".join(blocks)
+
+
+def create_test_prd_cif_file(path: Path, entries: list[dict]) -> None:
+    """Create a test PRD CIF file.
+
+    Handles .gz extension by writing gzip-compressed content.
+    """
+    content = create_test_prd_cif_content(entries)
+    doc = gemmi.cif.read_string(content)
+
+    if str(path).endswith(".gz"):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".cif", delete=False) as tmp:
+            doc.write_file(tmp.name)
+            with open(tmp.name, "rb") as f_in:
+                with gzip.open(path, "wb") as f_out:
+                    f_out.write(f_in.read())
+            Path(tmp.name).unlink()
+    else:
+        doc.write_file(str(path))
+
+
+def create_test_prdcc_cif_file(path: Path, entries: list[dict]) -> None:
+    """Create a test PRDCC CIF file.
+
+    Handles .gz extension by writing gzip-compressed content.
+    """
+    content = create_test_prdcc_cif_content(entries)
+    doc = gemmi.cif.read_string(content)
+
+    if str(path).endswith(".gz"):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".cif", delete=False) as tmp:
+            doc.write_file(tmp.name)
+            with open(tmp.name, "rb") as f_in:
+                with gzip.open(path, "wb") as f_out:
+                    f_out.write(f_in.read())
+            Path(tmp.name).unlink()
+    else:
+        doc.write_file(str(path))
+
+
+def create_test_settings(data_dir: Path) -> Settings:
+    """Create test settings."""
+    return Settings(
+        rdb=RdbConfig(nworkers=2, constring="test"),
+        pipelines={
+            "prd-cif": PipelineConfig(
+                deffile="schemas/prd.def.yml",
+                data=str(data_dir),
+            )
+        },
+    )
+
+
+def create_test_schema_def() -> SchemaDef:
+    """Create minimal test schema definition for prd."""
+    return SchemaDef(
+        schema_name="prd",
+        primary_key="prd_id",
+        tables=[
+            TableDef(
+                name="brief_summary",
+                columns=[
+                    ("prd_id", "TEXT"),
+                    ("name", "TEXT"),
+                    ("formula", "TEXT"),
+                    ("description", "TEXT"),
+                ],
+                primary_key=["prd_id"],
+            ),
+            TableDef(
+                name="pdbx_reference_molecule",
+                columns=[
+                    ("prd_id", "TEXT"),
+                    ("name", "TEXT"),
+                    ("formula", "TEXT"),
+                ],
+                primary_key=["prd_id"],
+            ),
+            TableDef(
+                name="chem_comp",
+                columns=[
+                    ("prd_id", "TEXT"),
+                    ("id", "TEXT"),
+                    ("formula", "TEXT"),
+                    ("name", "TEXT"),
+                ],
+                primary_key=["prd_id", "id"],
+            ),
+        ],
+    )
+
+
+class TestGenerateBriefSummaryPrd:
+    """Tests for _generate_brief_summary_prd function."""
+
+    def test_with_data(self) -> None:
+        """Generate brief_summary from pdbx_reference_molecule data."""
+        data = {
+            "pdbx_reference_molecule": [
+                {
+                    "prd_id": "PRD_000001",
+                    "name": "Cyclosporin A",
+                    "formula": "C62H111N11O12",
+                    "description": "Immunosuppressant",
+                },
+            ]
+        }
+        result = _generate_brief_summary_prd(data, "PRD_000001")
+
+        assert len(result) == 1
+        assert result[0]["prd_id"] == "PRD_000001"
+        assert result[0]["name"] == "Cyclosporin A"
+        assert result[0]["formula"] == "C62H111N11O12"
+
+    def test_without_data(self) -> None:
+        """Return empty list when no pdbx_reference_molecule data."""
+        data = {}
+        result = _generate_brief_summary_prd(data, "PRD_000001")
+
+        assert len(result) == 0
+
+
+class TestPrdccTables:
+    """Tests for PRDCC_TABLES constant."""
+
+    def test_contains_expected_tables(self) -> None:
+        """PRDCC_TABLES contains expected chem_comp tables."""
+        assert "chem_comp" in PRDCC_TABLES
+        assert "chem_comp_atom" in PRDCC_TABLES
+        assert "chem_comp_bond" in PRDCC_TABLES
+
+    def test_does_not_contain_prd_tables(self) -> None:
+        """PRDCC_TABLES does not contain pdbx_reference tables."""
+        assert "pdbx_reference_molecule" not in PRDCC_TABLES
+        assert "brief_summary" not in PRDCC_TABLES
+
+
+class TestFindCifFiles:
+    """Tests for PrdCifPipeline._find_cif_files()."""
+
+    def test_direct_path(self, tmp_path: Path) -> None:
+        """Find CIF files at direct path."""
+        prd_path = tmp_path / "prd-all.cif.gz"
+        prdcc_path = tmp_path / "prdcc-all.cif.gz"
+        create_test_prd_cif_file(prd_path, [{"id": "PRD_000001"}])
+        create_test_prdcc_cif_file(prdcc_path, [{"id": "PRDCC_000001"}])
+
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["prd-cif"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PrdCifPipeline(settings, config, schema_def)
+        found_prd, found_prdcc = pipeline._find_cif_files()
+
+        assert found_prd == prd_path
+        assert found_prdcc == prdcc_path
+
+    def test_prd_only(self, tmp_path: Path) -> None:
+        """Find PRD file when PRDCC is missing."""
+        prd_path = tmp_path / "prd-all.cif.gz"
+        create_test_prd_cif_file(prd_path, [{"id": "PRD_000001"}])
+
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["prd-cif"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PrdCifPipeline(settings, config, schema_def)
+        found_prd, found_prdcc = pipeline._find_cif_files()
+
+        assert found_prd == prd_path
+        assert found_prdcc is None
+
+    def test_nested_path_rsync_quirk(self, tmp_path: Path) -> None:
+        """Find CIF files in nested directory (rsync quirk)."""
+        nested_dir = tmp_path / "prd-all.cif.gz"
+        nested_dir.mkdir()
+        prd_path = nested_dir / "prd-all.cif.gz"
+        create_test_prd_cif_file(prd_path, [{"id": "PRD_000001"}])
+
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["prd-cif"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PrdCifPipeline(settings, config, schema_def)
+        found_prd, found_prdcc = pipeline._find_cif_files()
+
+        assert found_prd == prd_path
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        """Return None when PRD CIF file not found."""
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["prd-cif"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PrdCifPipeline(settings, config, schema_def)
+        found_prd, found_prdcc = pipeline._find_cif_files()
+
+        assert found_prd is None
+        assert found_prdcc is None
+
+    def test_directory_not_exists(self, tmp_path: Path) -> None:
+        """Return None when data directory doesn't exist."""
+        settings = create_test_settings(tmp_path / "nonexistent")
+        config = settings.pipelines["prd-cif"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PrdCifPipeline(settings, config, schema_def)
+        found_prd, found_prdcc = pipeline._find_cif_files()
+
+        assert found_prd is None
+
+
+class TestProcessPrdCifChunk:
+    """Tests for _process_prd_cif_chunk function."""
+
+    def test_process_single_block(self, tmp_path: Path) -> None:
+        """Process a single PRD block chunk."""
+        prd_path = tmp_path / "prd.cif"
+        prdcc_path = tmp_path / "prdcc.cif"
+        create_test_prd_cif_file(
+            prd_path,
+            [{"id": "PRD_000001", "name": "Test", "formula": "C10H20"}],
+        )
+        create_test_prdcc_cif_file(
+            prdcc_path,
+            [{"id": "PRDCC_000001", "comp_id": "TST", "formula": "C10H20"}],
+        )
+
+        schema_def = create_test_schema_def()
+
+        results = _process_prd_cif_chunk(
+            str(prd_path),
+            str(prdcc_path),
+            start_idx=0,
+            end_idx=1,
+            schema_def=schema_def,
+            conninfo="mock://test",
+        )
+
+        assert len(results) == 1
+        assert results[0].entry_id == "PRD_000001"
+
+    def test_process_without_prdcc(self, tmp_path: Path) -> None:
+        """Process PRD blocks without PRDCC file."""
+        prd_path = tmp_path / "prd.cif"
+        create_test_prd_cif_file(
+            prd_path,
+            [{"id": "PRD_000001", "name": "Test", "formula": "C10H20"}],
+        )
+
+        schema_def = create_test_schema_def()
+
+        results = _process_prd_cif_chunk(
+            str(prd_path),
+            None,  # No PRDCC file
+            start_idx=0,
+            end_idx=1,
+            schema_def=schema_def,
+            conninfo="mock://test",
+        )
+
+        assert len(results) == 1
+        assert results[0].entry_id == "PRD_000001"
+
+    def test_process_multiple_blocks(self, tmp_path: Path) -> None:
+        """Process multiple PRD blocks in a chunk."""
+        prd_path = tmp_path / "prd.cif"
+        prdcc_path = tmp_path / "prdcc.cif"
+        create_test_prd_cif_file(
+            prd_path,
+            [
+                {"id": "PRD_000001"},
+                {"id": "PRD_000002"},
+                {"id": "PRD_000003"},
+            ],
+        )
+        create_test_prdcc_cif_file(
+            prdcc_path,
+            [
+                {"id": "PRDCC_000001"},
+                {"id": "PRDCC_000002"},
+            ],
+        )
+
+        schema_def = create_test_schema_def()
+
+        results = _process_prd_cif_chunk(
+            str(prd_path),
+            str(prdcc_path),
+            start_idx=0,
+            end_idx=3,
+            schema_def=schema_def,
+            conninfo="mock://test",
+        )
+
+        assert len(results) == 3
+        entry_ids = {r.entry_id for r in results}
+        assert entry_ids == {"PRD_000001", "PRD_000002", "PRD_000003"}
+
+    def test_process_partial_chunk(self, tmp_path: Path) -> None:
+        """Process a partial range of blocks."""
+        prd_path = tmp_path / "prd.cif"
+        create_test_prd_cif_file(
+            prd_path,
+            [
+                {"id": "PRD_000001"},
+                {"id": "PRD_000002"},
+                {"id": "PRD_000003"},
+                {"id": "PRD_000004"},
+            ],
+        )
+
+        schema_def = create_test_schema_def()
+
+        results = _process_prd_cif_chunk(
+            str(prd_path),
+            None,
+            start_idx=1,
+            end_idx=3,
+            schema_def=schema_def,
+            conninfo="mock://test",
+        )
+
+        assert len(results) == 2
+        entry_ids = {r.entry_id for r in results}
+        assert entry_ids == {"PRD_000002", "PRD_000003"}
+
+
+class TestPrdCifPipelineRun:
+    """Tests for PrdCifPipeline.run() method."""
+
+    def test_run_returns_empty_when_no_file(self, tmp_path: Path) -> None:
+        """Run returns empty list when PRD CIF file not found."""
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["prd-cif"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PrdCifPipeline(settings, config, schema_def)
+        results = pipeline.run()
+
+        assert results == []
+
+    def test_run_sequential_for_small_count(self, tmp_path: Path) -> None:
+        """Run uses sequential processing for small block counts."""
+        prd_path = tmp_path / "prd-all.cif.gz"
+        prdcc_path = tmp_path / "prdcc-all.cif.gz"
+        create_test_prd_cif_file(
+            prd_path,
+            [{"id": f"PRD_{i:06d}"} for i in range(1, 6)],
+        )
+        create_test_prdcc_cif_file(
+            prdcc_path,
+            [{"id": f"PRDCC_{i:06d}"} for i in range(1, 4)],
+        )
+
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["prd-cif"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PrdCifPipeline(settings, config, schema_def)
+        results = pipeline.run(limit=5)
+
+        assert len(results) == 5
+
+    def test_run_respects_limit(self, tmp_path: Path) -> None:
+        """Run respects the limit parameter."""
+        prd_path = tmp_path / "prd-all.cif.gz"
+        create_test_prd_cif_file(
+            prd_path,
+            [{"id": f"PRD_{i:06d}"} for i in range(1, 51)],
+        )
+
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["prd-cif"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PrdCifPipeline(settings, config, schema_def)
+        results = pipeline.run(limit=10)
+
+        assert len(results) == 10


### PR DESCRIPTION
## Summary

Add alternative CIF-based pipeline for PRD (BIRD) data that reads from:
- `prd-all.cif.gz` (285KB, 1172 PRD blocks)
- `prdcc-all.cif.gz` (4.8MB, 800 PRDCC blocks)

Benefits:
- Single directory sync vs individual mmJSON files
- Reduced IO operations
- Parallel processing for performance

## Changes

- `sync.py`: Add `prd-cif` sync target (`rsync.pdbj.org::ftp_data/bird/prd/`)
- `prd.py`: Add `PrdCifPipeline` with parallel chunk processing
  - Handles two CIF files (PRD + PRDCC)
  - Gracefully handles missing PRDCC file
  - Module-level `PRDCC_TABLES` for table routing
- `update.py`: Support `prd-cif` pipeline routing
- `config.yml`: Add `prd-cif` pipeline config
- `tests/test_prd_cif.py`: 16 unit tests

## Usage

```bash
# Sync CIF files
pixi run mine2 sync prd-cif

# Run CIF pipeline
pixi run mine2 update prd-cif

# Traditional mmJSON version still available
pixi run mine2 update prd
```

## Test plan

- [x] Unit tests pass (64 total: 48 existing + 16 prd-cif)
- [x] Handles missing PRDCC file gracefully
- [x] Parallel processing verified