### PR TITLE
docs: Update documentation for CIF pipeline alternatives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ docs/                   # Architecture docs
 
 ## Pipelines
 
+### mmJSON Pipelines (Primary)
+
 | Pipeline | Format | Notes |
 |----------|--------|-------|
 | pdbj | mmJSON | Merges noatom + plus files via merge_data() |
@@ -54,6 +56,17 @@ docs/                   # Architecture docs
 | prd | mmJSON | Has TWO data blocks (PRD + PRDCC) |
 | vrpt | CIF | Uses gemmi.CifWalk for nested directory structure |
 | contacts | JSON | Array format, not mmJSON |
+
+### CIF Pipelines (Alternative)
+
+For users who already mirror CIF files from wwPDB/PDBj:
+
+| Pipeline | Source | Notes |
+|----------|--------|-------|
+| pdbj-cif | `divided/mmCIF/*.cif.gz` | File-based (~248k files), atom_site skipped |
+| cc-cif | `components.cif.gz` | Single file, ~40k blocks |
+| ccmodel-cif | `chem_comp_model.cif.gz` | Single file |
+| prd-cif | `prd-all.cif.gz` + `prdcc-all.cif.gz` | Dual file (PRD + PRDCC) |
 
 ## Key Patterns
 
@@ -80,7 +93,12 @@ from mine2.parsers.mmjson import normalize_column_name
 ### Category Transformation
 ```python
 from mine2.pipelines.base import transform_category
+
+# mmJSON: needs normalization
 rows = transform_category(rows, table, pk_value, pk_col, normalize_column_name)
+
+# CIF: no normalization needed (pass None)
+rows = transform_category(rows, table, pk_value, pk_col, None)
 ```
 
 ### Parallel Processing

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ RDB updater for MINE2 database. Synchronizes structural biology data from PDBj (
 - Multi-process parallel data loading with configurable workers
 - Schema-driven database management from YAML definitions
 - Support for multiple data formats (mmJSON, CIF)
-- Six data pipelines: pdbj, cc, ccmodel, prd, vrpt, contacts
+- 10 data pipelines: 6 primary (mmJSON) + 4 CIF alternatives
+- CIF pipelines for users who already mirror wwPDB/PDBj CIF files
 
 ## Requirements
 
@@ -68,11 +69,13 @@ pixi run mine2 --help
 
 # Sync data from PDBj
 pixi run mine2 sync [targets...]
-# Targets: pdbj, cc, ccmodel, prd, vrpt, contacts, schemas, dictionaries
+# Targets: pdbj, pdbj-cif, pdbj-plus, cc, cc-cif, ccmodel, ccmodel-cif,
+#          prd, prd-cif, vrpt, contacts, schemas, dictionaries
 
 # Update database
 pixi run mine2 update [pipelines...]
-# Pipelines: pdbj, cc, ccmodel, prd, vrpt, contacts
+# Pipelines: pdbj, pdbj-cif, cc, cc-cif, ccmodel, ccmodel-cif,
+#            prd, prd-cif, vrpt, contacts
 
 # Full update (sync + update)
 pixi run mine2 all
@@ -102,6 +105,8 @@ pixi run mine2 update pdbj --limit 100
 
 ## Pipelines
 
+### Primary Pipelines (mmJSON)
+
 | Pipeline | Description | Data Format |
 |----------|-------------|-------------|
 | pdbj | Main structure data (mmjson-noatom + mmjson-plus) | mmJSON |
@@ -110,6 +115,17 @@ pixi run mine2 update pdbj --limit 100
 | prd | BIRD (Biologically Interesting Reference Dictionary) | mmJSON |
 | vrpt | Validation reports | CIF |
 | contacts | Protein-protein contact data | JSON |
+
+### CIF Alternative Pipelines
+
+For users who already mirror CIF files from wwPDB/PDBj:
+
+| Pipeline | Description | Data Format |
+|----------|-------------|-------------|
+| pdbj-cif | Main structure data from mmCIF (~248k files) | CIF |
+| cc-cif | Chemical component dictionary (components.cif.gz) | CIF |
+| ccmodel-cif | Chemical component models (chem_comp_model.cif.gz) | CIF |
+| prd-cif | BIRD data (prd-all.cif.gz + prdcc-all.cif.gz) | CIF |
 
 ## Database Management
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -164,6 +164,27 @@ Edit `src/mine2/cli.py` to add the pipeline name to `PIPELINES` list.
 
 ## Pipeline Patterns
 
+### CIF Pipelines (Alternative to mmJSON)
+
+For users who already mirror CIF files from wwPDB/PDBj, `-cif` variants are available:
+
+| Pipeline | Pattern | Source Files |
+|----------|---------|--------------|
+| pdbj-cif | File-based | `divided/mmCIF/{middle2}/{pdbid}.cif.gz` (~248k files) |
+| cc-cif | Single-file | `components.cif.gz` (~40k blocks) |
+| ccmodel-cif | Single-file | `chem_comp_model.cif.gz` |
+| prd-cif | Dual-file | `prd-all.cif.gz` + `prdcc-all.cif.gz` |
+
+**Key difference**: CIF uses plain column names, mmJSON uses bracket notation.
+
+```python
+# mmJSON: needs normalization
+transform_category(rows, table, pk, pk_col, normalize_column_name)
+
+# CIF: no normalization
+transform_category(rows, table, pk, pk_col, None)
+```
+
 ### mmJSON Data (Standard)
 
 Use for most PDBj data:
@@ -176,15 +197,35 @@ data = parse_mmjson_file(filepath)  # Row-oriented dict
 rows = data.get("category_name", [])
 ```
 
-### CIF Data
+### CIF Data (File-based)
 
-Use for validation reports:
+Use for pdbj-cif (individual CIF files):
 
 ```python
 from mine2.parsers.cif import parse_cif_file
 
 data = parse_cif_file(filepath)  # Row-oriented dict (same format as mmJSON)
 rows = data.get("category_name", [])
+```
+
+### CIF Data (Single-file with Chunks)
+
+Use for cc-cif, ccmodel-cif (large single CIF files with many blocks):
+
+```python
+import gemmi
+
+doc = gemmi.cif.read(str(cif_path))
+total_blocks = len(doc)
+
+# Process in chunks for parallel loading
+chunk_size = 100
+for start in range(0, total_blocks, chunk_size):
+    end = min(start + chunk_size, total_blocks)
+    for i in range(start, end):
+        block = doc[i]
+        entry_id = block.name
+        # Process block...
 ```
 
 ### Custom JSON Format
@@ -199,9 +240,9 @@ with gzip.open(filepath, "rt") as f:
     data = json.load(f)
 ```
 
-### Multiple Data Blocks
+### Multiple Data Blocks (mmJSON)
 
-For files with multiple data blocks (like PRD):
+For mmJSON files with multiple data blocks (like PRD):
 
 ```python
 from mine2.parsers.cif import parse_mmjson_file_blocks
@@ -211,6 +252,26 @@ blocks = parse_mmjson_file_blocks(filepath)
 
 prd_data = blocks.get(f"PRD_{entry_id}", {})
 prdcc_data = blocks.get(f"PRDCC_{entry_id}", {})
+```
+
+### Dual-File CIF (prd-cif)
+
+For CIF pipelines with related data in separate files:
+
+```python
+# prd-cif: PRD entries + PRDCC entries in separate files
+prd_doc = gemmi.cif.read(str(prd_cif_path))      # prd-all.cif.gz
+prdcc_doc = gemmi.cif.read(str(prdcc_cif_path))  # prdcc-all.cif.gz
+
+# Build PRDCC lookup by entry_id
+prdcc_lookup = {block.name: block for block in prdcc_doc}
+
+# Route tables to correct file
+PRDCC_TABLES = {"chem_comp", "chem_comp_atom", ...}
+if table.name in PRDCC_TABLES:
+    block = prdcc_lookup.get(f"PRDCC_{entry_id}")
+else:
+    block = prd_block
 ```
 
 ### Custom File Discovery


### PR DESCRIPTION
## Summary
- Update documentation to reflect the new CIF pipeline alternatives
- Document patterns for different CIF pipeline types

## Changes
- **CLAUDE.md**: Add CIF pipelines table and category transformation examples
- **README.md**: Update features, sync targets, update pipelines, and pipelines table
- **docs/pipelines.md**: Add CIF pipeline patterns (file-based, single-file chunks, dual-file)

## Test plan
- [x] Documentation accurately reflects implemented pipelines
- [x] Code examples are correct