### PR TITLE
feat: Make CIF default format for dual-format pipelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,27 +47,34 @@ docs/                   # Architecture docs
 
 ## Pipelines
 
-### mmJSON Pipelines (Primary)
+### CIF Pipelines (Default)
 
-| Pipeline | Format | Notes |
-|----------|--------|-------|
-| pdbj | mmJSON | Merges noatom + plus files via merge_data() |
-| cc | mmJSON | Chemical component dictionary |
-| ccmodel | mmJSON | Component 3D models |
-| prd | mmJSON | Has TWO data blocks (PRD + PRDCC) |
-| vrpt | CIF | Uses gemmi.CifWalk for nested directory structure |
-| contacts | JSON | Array format, not mmJSON |
-
-### CIF Pipelines (Alternative)
-
-For users who already mirror CIF files from wwPDB/PDBj:
+CIF is the default format for dual-format pipelines:
 
 | Pipeline | Source | Notes |
 |----------|--------|-------|
-| pdbj-cif | `divided/mmCIF/*.cif.gz` | File-based (~248k files), atom_site skipped |
-| cc-cif | `components.cif.gz` | Single file, ~40k blocks |
-| ccmodel-cif | `chem_comp_model.cif.gz` | Single file |
-| prd-cif | `prd-all.cif.gz` + `prdcc-all.cif.gz` | Dual file (PRD + PRDCC) |
+| pdbj | `divided/mmCIF/*.cif.gz` | File-based (~248k files), atom_site skipped |
+| cc | `components.cif.gz` | Single file, ~40k blocks |
+| ccmodel | `chem_comp_model.cif.gz` | Single file |
+| prd | `prd-all.cif.gz` + `prdcc-all.cif.gz` | Dual file (PRD + PRDCC) |
+| vrpt | `validation_reports/**/*.cif.gz` | Uses gemmi.CifWalk for nested directory structure |
+| contacts | `contacts/**/*.json` | Array format, not mmJSON |
+
+### mmJSON Pipelines (Optional)
+
+For users who prefer mmJSON format, use the `-json` suffix:
+
+| Pipeline | Format | Notes |
+|----------|--------|-------|
+| pdbj-json | mmJSON | Merges noatom + plus files via merge_data() |
+| cc-json | mmJSON | Chemical component dictionary |
+| ccmodel-json | mmJSON | Component 3D models |
+| prd-json | mmJSON | Has TWO data blocks (PRD + PRDCC) |
+
+### Backward Compatibility
+
+Legacy pipeline names (`pdbj-cif`, `cc-cif`, etc.) are still accepted but deprecated.
+They emit a warning and run the corresponding CIF pipeline.
 
 ## Key Patterns
 
@@ -117,7 +124,7 @@ smiles = Chem.MolToSmiles(mol, canonical=True)
 ```
 
 ### RDKit PostgreSQL Cartridge
-Chemical searches use RDKit extension (auto-configured on `cc`/`cc-cif` pipeline run):
+Chemical searches use RDKit extension (auto-configured on `cc`/`cc-json` pipeline run):
 ```sql
 -- Substructure search
 SELECT * FROM cc.brief_summary WHERE mol @> 'c1ccccc1'::mol;

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ RDB updater for MINE2 database. Synchronizes structural biology data from PDBj (
 
 - Multi-process parallel data loading with configurable workers
 - Schema-driven database management from YAML definitions
-- Support for multiple data formats (mmJSON, CIF)
-- 10 data pipelines: 6 primary (mmJSON) + 4 CIF alternatives
-- CIF pipelines for users who already mirror wwPDB/PDBj CIF files
+- Support for multiple data formats (CIF default, mmJSON optional)
+- 10 data pipelines: CIF default for dual-format pipelines, `-json` suffix for mmJSON
+- Works seamlessly with wwPDB/PDBj mirrored data
 
 ## Requirements
 
@@ -66,13 +66,14 @@ pixi run mine2 --help
 
 # Sync data from PDBj
 pixi run mine2 sync [targets...]
-# Targets: pdbj, pdbj-cif, pdbj-plus, cc, cc-cif, ccmodel, ccmodel-cif,
-#          prd, prd-cif, vrpt, contacts, schemas, dictionaries
+# Targets: pdbj (CIF), pdbj-json (mmJSON), pdbj-plus, cc, cc-json,
+#          ccmodel, ccmodel-json, prd, prd-json, vrpt, contacts,
+#          schemas, dictionaries
 
 # Update database
 pixi run mine2 update [pipelines...]
-# Pipelines: pdbj, pdbj-cif, cc, cc-cif, ccmodel, ccmodel-cif,
-#            prd, prd-cif, vrpt, contacts
+# Pipelines: pdbj (CIF), pdbj-json (mmJSON), cc, cc-json, ccmodel,
+#            ccmodel-json, prd, prd-json, vrpt, contacts
 
 # Full update (sync + update)
 pixi run mine2 all
@@ -102,27 +103,34 @@ pixi run mine2 update pdbj --limit 100
 
 ## Pipelines
 
-### Primary Pipelines (mmJSON)
+### Default Pipelines (CIF)
+
+CIF is the default format for dual-format pipelines:
 
 | Pipeline | Description | Data Format |
 |----------|-------------|-------------|
-| pdbj | Main structure data (mmjson-noatom + mmjson-plus) | mmJSON |
-| cc | Chemical component dictionary | mmJSON |
-| ccmodel | Chemical component model data | mmJSON |
-| prd | BIRD (Biologically Interesting Reference Dictionary) | mmJSON |
+| pdbj | Main structure data from mmCIF (~248k files) | CIF |
+| cc | Chemical component dictionary (components.cif.gz) | CIF |
+| ccmodel | Chemical component models (chem_comp_model.cif.gz) | CIF |
+| prd | BIRD data (prd-all.cif.gz + prdcc-all.cif.gz) | CIF |
 | vrpt | Validation reports | CIF |
 | contacts | Protein-protein contact data | JSON |
 
-### CIF Alternative Pipelines
+### mmJSON Pipelines (Optional)
 
-For users who already mirror CIF files from wwPDB/PDBj:
+For users who prefer mmJSON format, use the `-json` suffix:
 
 | Pipeline | Description | Data Format |
 |----------|-------------|-------------|
-| pdbj-cif | Main structure data from mmCIF (~248k files) | CIF |
-| cc-cif | Chemical component dictionary (components.cif.gz) | CIF |
-| ccmodel-cif | Chemical component models (chem_comp_model.cif.gz) | CIF |
-| prd-cif | BIRD data (prd-all.cif.gz + prdcc-all.cif.gz) | CIF |
+| pdbj-json | Main structure data (mmjson-noatom + mmjson-plus) | mmJSON |
+| cc-json | Chemical component dictionary | mmJSON |
+| ccmodel-json | Chemical component model data | mmJSON |
+| prd-json | BIRD data | mmJSON |
+
+### Backward Compatibility
+
+Legacy pipeline names (`pdbj-cif`, `cc-cif`, etc.) are still accepted but deprecated.
+They will emit a warning and run the corresponding CIF pipeline.
 
 ## Database Management
 
@@ -138,7 +146,7 @@ pixi run db-status
 
 ### RDKit Extension Setup
 
-RDKit extension and mol column are **automatically configured** when running the `cc` or `cc-cif` pipeline.
+RDKit extension and mol column are **automatically configured** when running the `cc` or `cc-json` pipeline.
 
 > **Note**: Requires superuser privileges for initial `CREATE EXTENSION rdkit`.
 > If auto-setup fails, run manually: `psql -d mine2 -f scripts/init_rdkit.sql`

--- a/src/mine2/cli.py
+++ b/src/mine2/cli.py
@@ -39,7 +39,7 @@ def sync(
     targets: Annotated[
         Optional[list[str]],
         typer.Argument(
-            help="Sync targets: pdbj, cc, ccmodel, prd, vrpt, contacts, schemas, dictionaries"
+            help="Sync targets: pdbj (CIF), pdbj-json (mmJSON), cc, cc-json, ccmodel, ccmodel-json, prd, prd-json, vrpt, contacts, schemas, dictionaries"
         ),
     ] = None,
     config: Annotated[
@@ -64,7 +64,9 @@ def sync(
 def update(
     pipelines: Annotated[
         Optional[list[str]],
-        typer.Argument(help="Pipelines to run: pdbj, cc, ccmodel, prd, vrpt, contacts"),
+        typer.Argument(
+            help="Pipelines: pdbj (CIF), pdbj-json (mmJSON), cc, cc-json, ccmodel, ccmodel-json, prd, prd-json, vrpt, contacts"
+        ),
     ] = None,
     config: Annotated[
         Path,

--- a/src/mine2/commands/sync.py
+++ b/src/mine2/commands/sync.py
@@ -6,56 +6,58 @@ from pathlib import Path
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from mine2.commands.utils import resolve_legacy_aliases
 from mine2.config import Settings
 
 console = Console()
 
 # Default sync targets with their rsync configurations
+# CIF is default, -json suffix for mmJSON
 SYNC_TARGETS: dict[str, dict] = {
-    "pdbj": {
-        "source": "rsync.pdbj.org::ftp_data/structures/divided/mmjson-noatom/",
-        "dest": "data/mmjson-noatom/",
-        "options": ["-avz", "--delete"],
-    },
-    "pdbj-cif": {
+    "pdbj": {  # CIF (default)
         "source": "rsync.pdbj.org::ftp_data/structures/divided/mmCIF/",
         "dest": "data/structures/divided/mmCIF/",
         "options": ["-avz", "--delete"],
     },
-    "pdbj-plus": {
+    "pdbj-json": {  # mmJSON (requires suffix)
+        "source": "rsync.pdbj.org::ftp_data/structures/divided/mmjson-noatom/",
+        "dest": "data/mmjson-noatom/",
+        "options": ["-avz", "--delete"],
+    },
+    "pdbj-plus": {  # mmJSON plus data
         "source": "rsync.pdbj.org::mine/ftp_data/mine_data/mmjson-plus/",
         "dest": "pdbj/pdbjplus/",
         "options": ["-avz", "--delete"],
     },
-    "cc": {
-        "source": "rsync.pdbj.org::ftp_data/component-models/complete/chem_comp-mmjson/",
-        "dest": "data/cc/",
-        "options": ["-avz", "--delete"],
-    },
-    "cc-cif": {
+    "cc": {  # CIF (default)
         "source": "rsync.pdbj.org::ftp_data/monomers/components.cif.gz",
         "dest": "data/monomers/",
         "options": ["-avz"],
     },
-    "ccmodel": {
-        "source": "rsync.pdbj.org::ftp_data/component-models/complete/chem_comp_model-mmjson/",
-        "dest": "data/ccmodel/",
+    "cc-json": {  # mmJSON (requires suffix)
+        "source": "rsync.pdbj.org::ftp_data/component-models/complete/chem_comp-mmjson/",
+        "dest": "data/cc/",
         "options": ["-avz", "--delete"],
     },
-    "ccmodel-cif": {
+    "ccmodel": {  # CIF (default)
         "source": "rsync.pdbj.org::ftp_data/component-models/complete/chem_comp_model.cif.gz",
         "dest": "data/component-models/complete/",
         "options": ["-avz"],
     },
-    "prd": {
-        "source": "rsync.pdbj.org::ftp_data/bird/mmjson/",
-        "dest": "data/prd/",
+    "ccmodel-json": {  # mmJSON (requires suffix)
+        "source": "rsync.pdbj.org::ftp_data/component-models/complete/chem_comp_model-mmjson/",
+        "dest": "data/ccmodel/",
         "options": ["-avz", "--delete"],
     },
-    "prd-cif": {
+    "prd": {  # CIF (default)
         "source": "rsync.pdbj.org::ftp_data/bird/prd/",
         "dest": "data/bird/prd/",
         "options": ["-avz"],
+    },
+    "prd-json": {  # mmJSON (requires suffix)
+        "source": "rsync.pdbj.org::ftp_data/bird/mmjson/",
+        "dest": "data/prd/",
+        "options": ["-avz", "--delete"],
     },
     "vrpt": {
         # Fixed: use include/exclude pattern to avoid timeout
@@ -83,6 +85,14 @@ SYNC_TARGETS: dict[str, dict] = {
         "dest": "data/dictionaries/",
         "options": ["-avz", "--delete"],
     },
+}
+
+# Legacy aliases for backward compatibility (deprecated)
+LEGACY_SYNC_ALIASES = {
+    "pdbj-cif": "pdbj",
+    "cc-cif": "cc",
+    "ccmodel-cif": "ccmodel",
+    "prd-cif": "prd",
 }
 
 
@@ -130,6 +140,9 @@ def run_sync(
     # If no targets specified, sync all
     if not targets:
         targets = list(SYNC_TARGETS.keys())
+
+    # Resolve legacy aliases with deprecation warnings
+    targets = resolve_legacy_aliases(targets, LEGACY_SYNC_ALIASES, "Sync target")
 
     # Validate targets
     invalid_targets = [t for t in targets if t not in SYNC_TARGETS]

--- a/src/mine2/commands/update.py
+++ b/src/mine2/commands/update.py
@@ -4,25 +4,34 @@ from pathlib import Path
 
 from rich.console import Console
 
+from mine2.commands.utils import resolve_legacy_aliases
 from mine2.config import Settings
 from mine2.db.connection import close_pool, init_pool
 from mine2.db.loader import ensure_schema, load_schema_def
 
 console = Console()
 
-# Available pipelines
+# Available pipelines (CIF is default, -json suffix for mmJSON)
 AVAILABLE_PIPELINES = [
-    "pdbj",
-    "pdbj-cif",
-    "cc",
-    "cc-cif",
-    "ccmodel",
-    "ccmodel-cif",
-    "prd",
-    "prd-cif",
+    "pdbj",  # CIF (default)
+    "pdbj-json",  # mmJSON (requires suffix)
+    "cc",  # CIF (default)
+    "cc-json",  # mmJSON (requires suffix)
+    "ccmodel",  # CIF (default)
+    "ccmodel-json",  # mmJSON (requires suffix)
+    "prd",  # CIF (default)
+    "prd-json",  # mmJSON (requires suffix)
     "vrpt",
     "contacts",
 ]
+
+# Legacy aliases for backward compatibility (deprecated)
+LEGACY_ALIASES = {
+    "pdbj-cif": "pdbj",
+    "cc-cif": "cc",
+    "ccmodel-cif": "ccmodel",
+    "prd-cif": "prd",
+}
 
 
 def run_update(
@@ -38,6 +47,9 @@ def run_update(
     # If no pipelines specified, run all
     if not pipelines:
         pipelines = AVAILABLE_PIPELINES
+
+    # Resolve legacy aliases with deprecation warnings
+    pipelines = resolve_legacy_aliases(pipelines, LEGACY_ALIASES, "Pipeline")
 
     # Validate pipelines
     invalid = [p for p in pipelines if p not in AVAILABLE_PIPELINES]
@@ -97,15 +109,22 @@ def _get_pipeline_runner(pipeline_name: str) -> tuple[str, str]:
     Returns:
         Tuple of (module_name, function_name)
     """
-    # Special cases where pipeline name differs from module
-    special_cases = {
-        "pdbj-cif": ("pdbj", "run_cif"),
-        "cc-cif": ("cc", "run_cif"),
-        "ccmodel-cif": ("ccmodel", "run_cif"),
-        "prd-cif": ("prd", "run_cif"),
+    # mmJSON pipelines require -json suffix, dispatch to run()
+    json_pipelines = {
+        "pdbj-json": ("pdbj", "run"),
+        "cc-json": ("cc", "run"),
+        "ccmodel-json": ("ccmodel", "run"),
+        "prd-json": ("prd", "run"),
     }
-    if pipeline_name in special_cases:
-        return special_cases[pipeline_name]
+    if pipeline_name in json_pipelines:
+        return json_pipelines[pipeline_name]
+
+    # Base names now use CIF (run_cif) as default
+    cif_defaults = {"pdbj", "cc", "ccmodel", "prd"}
+    if pipeline_name in cif_defaults:
+        return (pipeline_name, "run_cif")
+
+    # Other pipelines (vrpt, contacts) use their standard run()
     return (pipeline_name, "run")
 
 

--- a/src/mine2/commands/utils.py
+++ b/src/mine2/commands/utils.py
@@ -1,0 +1,40 @@
+"""Shared utilities for commands."""
+
+import warnings
+
+from rich.console import Console
+
+console = Console()
+
+
+def resolve_legacy_aliases(
+    items: list[str],
+    aliases: dict[str, str],
+    item_type: str = "name",
+) -> list[str]:
+    """Resolve legacy aliases with deprecation warnings.
+
+    Args:
+        items: List of items to resolve
+        aliases: Dictionary mapping legacy names to new names
+        item_type: Type of item for warning message (e.g., "Pipeline", "Sync target")
+
+    Returns:
+        List of resolved items with legacy names replaced
+    """
+    resolved = []
+    for item in items:
+        if item in aliases:
+            new_name = aliases[item]
+            console.print(
+                f"[yellow]Warning: '{item}' is deprecated. Use '{new_name}' instead.[/yellow]"
+            )
+            warnings.warn(
+                f"{item_type} '{item}' is deprecated. Use '{new_name}' instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            resolved.append(new_name)
+        else:
+            resolved.append(item)
+    return resolved

--- a/tests/test_cc_cif.py
+++ b/tests/test_cc_cif.py
@@ -1,4 +1,4 @@
-"""Tests for cc-cif pipeline."""
+"""Tests for cc pipeline (CIF format)."""
 
 import gzip
 from pathlib import Path
@@ -70,7 +70,7 @@ def create_test_settings(data_dir: Path) -> Settings:
     return Settings(
         rdb=RdbConfig(nworkers=2, constring="test"),
         pipelines={
-            "cc-cif": PipelineConfig(
+            "cc": PipelineConfig(
                 deffile="schemas/cc.def.yml",
                 data=str(data_dir),
             )
@@ -102,7 +102,7 @@ class TestFindCifFile:
         create_test_cif_file(cif_path, [{"id": "ATP"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["cc-cif"]
+        config = settings.pipelines["cc"]
         schema_def = create_test_schema_def()
 
         pipeline = CcCifPipeline(settings, config, schema_def)
@@ -119,7 +119,7 @@ class TestFindCifFile:
         create_test_cif_file(cif_path, [{"id": "ATP"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["cc-cif"]
+        config = settings.pipelines["cc"]
         schema_def = create_test_schema_def()
 
         pipeline = CcCifPipeline(settings, config, schema_def)
@@ -136,7 +136,7 @@ class TestFindCifFile:
         create_test_cif_file(cif_path, [{"id": "ATP"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["cc-cif"]
+        config = settings.pipelines["cc"]
         schema_def = create_test_schema_def()
 
         pipeline = CcCifPipeline(settings, config, schema_def)
@@ -147,7 +147,7 @@ class TestFindCifFile:
     def test_not_found(self, tmp_path: Path) -> None:
         """Return None when CIF file not found."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["cc-cif"]
+        config = settings.pipelines["cc"]
         schema_def = create_test_schema_def()
 
         pipeline = CcCifPipeline(settings, config, schema_def)
@@ -158,7 +158,7 @@ class TestFindCifFile:
     def test_directory_not_exists(self, tmp_path: Path) -> None:
         """Return None when data directory doesn't exist."""
         settings = create_test_settings(tmp_path.joinpath("nonexistent"))
-        config = settings.pipelines["cc-cif"]
+        config = settings.pipelines["cc"]
         schema_def = create_test_schema_def()
 
         pipeline = CcCifPipeline(settings, config, schema_def)
@@ -228,7 +228,7 @@ class TestCcCifPipelineRun:
     def test_run_returns_empty_when_no_file(self, tmp_path: Path) -> None:
         """Run returns empty list when CIF file not found."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["cc-cif"]
+        config = settings.pipelines["cc"]
         schema_def = create_test_schema_def()
 
         pipeline = CcCifPipeline(settings, config, schema_def)
@@ -245,7 +245,7 @@ class TestCcCifPipelineRun:
         )
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["cc-cif"]
+        config = settings.pipelines["cc"]
         schema_def = create_test_schema_def()
 
         pipeline = CcCifPipeline(settings, config, schema_def)
@@ -264,7 +264,7 @@ class TestCcCifPipelineRun:
         )
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["cc-cif"]
+        config = settings.pipelines["cc"]
         schema_def = create_test_schema_def()
 
         pipeline = CcCifPipeline(settings, config, schema_def)

--- a/tests/test_ccmodel_cif.py
+++ b/tests/test_ccmodel_cif.py
@@ -1,4 +1,4 @@
-"""Tests for ccmodel-cif pipeline."""
+"""Tests for ccmodel pipeline (CIF format)."""
 
 import gzip
 from pathlib import Path
@@ -61,7 +61,7 @@ def create_test_settings(data_dir: Path) -> Settings:
     return Settings(
         rdb=RdbConfig(nworkers=2, constring="test"),
         pipelines={
-            "ccmodel-cif": PipelineConfig(
+            "ccmodel": PipelineConfig(
                 deffile="schemas/ccmodel.def.yml",
                 data=str(data_dir),
             )
@@ -123,7 +123,7 @@ class TestFindCifFile:
         create_test_ccmodel_cif_file(cif_path, [{"id": "M_DAL_00001"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["ccmodel-cif"]
+        config = settings.pipelines["ccmodel"]
         schema_def = create_test_schema_def()
 
         pipeline = CcmodelCifPipeline(settings, config, schema_def)
@@ -139,7 +139,7 @@ class TestFindCifFile:
         create_test_ccmodel_cif_file(cif_path, [{"id": "M_DAL_00001"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["ccmodel-cif"]
+        config = settings.pipelines["ccmodel"]
         schema_def = create_test_schema_def()
 
         pipeline = CcmodelCifPipeline(settings, config, schema_def)
@@ -155,7 +155,7 @@ class TestFindCifFile:
         create_test_ccmodel_cif_file(cif_path, [{"id": "M_DAL_00001"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["ccmodel-cif"]
+        config = settings.pipelines["ccmodel"]
         schema_def = create_test_schema_def()
 
         pipeline = CcmodelCifPipeline(settings, config, schema_def)
@@ -166,7 +166,7 @@ class TestFindCifFile:
     def test_not_found(self, tmp_path: Path) -> None:
         """Return None when CIF file not found."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["ccmodel-cif"]
+        config = settings.pipelines["ccmodel"]
         schema_def = create_test_schema_def()
 
         pipeline = CcmodelCifPipeline(settings, config, schema_def)
@@ -177,7 +177,7 @@ class TestFindCifFile:
     def test_directory_not_exists(self, tmp_path: Path) -> None:
         """Return None when data directory doesn't exist."""
         settings = create_test_settings(tmp_path.joinpath("nonexistent"))
-        config = settings.pipelines["ccmodel-cif"]
+        config = settings.pipelines["ccmodel"]
         schema_def = create_test_schema_def()
 
         pipeline = CcmodelCifPipeline(settings, config, schema_def)
@@ -238,7 +238,7 @@ class TestCcmodelCifPipelineRun:
     def test_run_returns_empty_when_no_file(self, tmp_path: Path) -> None:
         """Run returns empty list when CIF file not found."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["ccmodel-cif"]
+        config = settings.pipelines["ccmodel"]
         schema_def = create_test_schema_def()
 
         pipeline = CcmodelCifPipeline(settings, config, schema_def)
@@ -255,7 +255,7 @@ class TestCcmodelCifPipelineRun:
         )
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["ccmodel-cif"]
+        config = settings.pipelines["ccmodel"]
         schema_def = create_test_schema_def()
 
         pipeline = CcmodelCifPipeline(settings, config, schema_def)
@@ -272,7 +272,7 @@ class TestCcmodelCifPipelineRun:
         )
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["ccmodel-cif"]
+        config = settings.pipelines["ccmodel"]
         schema_def = create_test_schema_def()
 
         pipeline = CcmodelCifPipeline(settings, config, schema_def)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,140 @@
+"""Tests for command modules."""
+
+import warnings
+
+import pytest
+
+from mine2.commands.update import AVAILABLE_PIPELINES, LEGACY_ALIASES
+from mine2.commands.sync import LEGACY_SYNC_ALIASES, SYNC_TARGETS
+from mine2.commands.utils import resolve_legacy_aliases
+
+
+class TestLegacyAliases:
+    """Tests for legacy alias resolution."""
+
+    def test_all_update_legacy_aliases_resolve_to_valid_pipelines(self) -> None:
+        """All legacy update aliases should map to valid pipeline names."""
+        for legacy, new_name in LEGACY_ALIASES.items():
+            assert new_name in AVAILABLE_PIPELINES, (
+                f"Legacy alias '{legacy}' maps to invalid pipeline '{new_name}'"
+            )
+
+    def test_all_sync_legacy_aliases_resolve_to_valid_targets(self) -> None:
+        """All legacy sync aliases should map to valid sync targets."""
+        for legacy, new_name in LEGACY_SYNC_ALIASES.items():
+            assert new_name in SYNC_TARGETS, (
+                f"Legacy alias '{legacy}' maps to invalid sync target '{new_name}'"
+            )
+
+    def test_legacy_aliases_follow_naming_pattern(self) -> None:
+        """Legacy aliases should follow the -cif suffix pattern."""
+        for legacy in LEGACY_ALIASES:
+            assert legacy.endswith("-cif"), (
+                f"Legacy alias '{legacy}' should end with '-cif'"
+            )
+
+    def test_sync_legacy_aliases_follow_naming_pattern(self) -> None:
+        """Sync legacy aliases should follow the -cif suffix pattern."""
+        for legacy in LEGACY_SYNC_ALIASES:
+            assert legacy.endswith("-cif"), (
+                f"Legacy sync alias '{legacy}' should end with '-cif'"
+            )
+
+
+class TestResolveLegacyAliases:
+    """Tests for resolve_legacy_aliases utility function."""
+
+    def test_resolves_single_legacy_alias(self) -> None:
+        """Single legacy alias should be resolved."""
+        aliases = {"old-name": "new-name"}
+        result = resolve_legacy_aliases(["old-name"], aliases, "Test")
+        assert result == ["new-name"]
+
+    def test_preserves_non_legacy_names(self) -> None:
+        """Non-legacy names should be preserved unchanged."""
+        aliases = {"old-name": "new-name"}
+        result = resolve_legacy_aliases(["valid-name"], aliases, "Test")
+        assert result == ["valid-name"]
+
+    def test_resolves_mixed_list(self) -> None:
+        """Mixed list of legacy and non-legacy names should be resolved correctly."""
+        aliases = {"old1": "new1", "old2": "new2"}
+        result = resolve_legacy_aliases(
+            ["old1", "valid", "old2", "another"],
+            aliases,
+            "Test",
+        )
+        assert result == ["new1", "valid", "new2", "another"]
+
+    def test_emits_deprecation_warning(self) -> None:
+        """Using a legacy alias should emit a DeprecationWarning."""
+        aliases = {"old-name": "new-name"}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            resolve_legacy_aliases(["old-name"], aliases, "Pipeline")
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "old-name" in str(w[0].message)
+            assert "new-name" in str(w[0].message)
+            assert "Pipeline" in str(w[0].message)
+
+    def test_no_warning_for_valid_names(self) -> None:
+        """Non-legacy names should not emit warnings."""
+        aliases = {"old-name": "new-name"}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            resolve_legacy_aliases(["valid-name"], aliases, "Test")
+            assert len(w) == 0
+
+    def test_empty_list_returns_empty(self) -> None:
+        """Empty input list should return empty list."""
+        aliases = {"old-name": "new-name"}
+        result = resolve_legacy_aliases([], aliases, "Test")
+        assert result == []
+
+    def test_empty_aliases_returns_unchanged(self) -> None:
+        """Empty aliases dict should return input unchanged."""
+        result = resolve_legacy_aliases(["name1", "name2"], {}, "Test")
+        assert result == ["name1", "name2"]
+
+
+class TestPipelineNamingConsistency:
+    """Tests for pipeline naming consistency."""
+
+    def test_cif_pipelines_have_json_counterparts(self) -> None:
+        """Each CIF default pipeline should have a -json counterpart."""
+        cif_defaults = {"pdbj", "cc", "ccmodel", "prd"}
+        for name in cif_defaults:
+            json_name = f"{name}-json"
+            assert json_name in AVAILABLE_PIPELINES, (
+                f"CIF pipeline '{name}' missing -json counterpart '{json_name}'"
+            )
+
+    def test_json_pipelines_have_cif_defaults(self) -> None:
+        """Each -json pipeline should have a CIF default counterpart."""
+        for name in AVAILABLE_PIPELINES:
+            if name.endswith("-json"):
+                base_name = name[:-5]  # Remove '-json' suffix
+                assert base_name in AVAILABLE_PIPELINES, (
+                    f"JSON pipeline '{name}' missing CIF default '{base_name}'"
+                )
+
+    def test_no_cif_suffix_in_available_pipelines(self) -> None:
+        """Available pipelines should not have -cif suffix (use legacy aliases)."""
+        for name in AVAILABLE_PIPELINES:
+            assert not name.endswith("-cif"), (
+                f"Pipeline '{name}' should not use -cif suffix; "
+                "CIF is now the default"
+            )
+
+
+class TestSyncTargetNamingConsistency:
+    """Tests for sync target naming consistency."""
+
+    def test_no_cif_suffix_in_sync_targets(self) -> None:
+        """Sync targets should not have -cif suffix (use legacy aliases)."""
+        for name in SYNC_TARGETS:
+            assert not name.endswith("-cif"), (
+                f"Sync target '{name}' should not use -cif suffix; "
+                "CIF is now the default"
+            )

--- a/tests/test_pdbj_cif.py
+++ b/tests/test_pdbj_cif.py
@@ -1,4 +1,4 @@
-"""Tests for pdbj-cif pipeline."""
+"""Tests for pdbj pipeline (CIF format)."""
 
 import gzip
 from pathlib import Path
@@ -60,7 +60,7 @@ def create_test_settings(data_dir: Path) -> Settings:
     return Settings(
         rdb=RdbConfig(nworkers=2, constring="test"),
         pipelines={
-            "pdbj-cif": PipelineConfig(
+            "pdbj": PipelineConfig(
                 deffile="schemas/pdbj.def.yml",
                 data=str(data_dir),
             )
@@ -100,7 +100,7 @@ class TestExtractEntryId:
     def test_cif_gz_extension(self, tmp_path: Path) -> None:
         """Extract entry ID from .cif.gz filename."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -111,7 +111,7 @@ class TestExtractEntryId:
     def test_plain_cif_extension(self, tmp_path: Path) -> None:
         """Extract entry ID from .cif filename."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -133,7 +133,7 @@ class TestFindJobs:
         create_test_pdbj_cif_file(cif_path, [{"id": "100d"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -153,7 +153,7 @@ class TestFindJobs:
             create_test_pdbj_cif_file(cif_path, [{"id": pdb_id}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -173,7 +173,7 @@ class TestFindJobs:
             create_test_pdbj_cif_file(cif_path, [{"id": f"{i:03d}d"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -184,7 +184,7 @@ class TestFindJobs:
     def test_empty_directory(self, tmp_path: Path) -> None:
         """Find jobs returns empty list for empty directory."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -195,7 +195,7 @@ class TestFindJobs:
     def test_nonexistent_directory(self, tmp_path: Path) -> None:
         """Find jobs returns empty list for nonexistent directory."""
         settings = create_test_settings(tmp_path.joinpath("nonexistent"))
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -213,7 +213,7 @@ class TestProcessJob:
         create_test_pdbj_cif_file(cif_path, [{"id": "100d"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -233,7 +233,7 @@ class TestPdbjCifPipelineRun:
     def test_run_returns_empty_when_no_files(self, tmp_path: Path) -> None:
         """Run returns empty list when no CIF files found."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -251,7 +251,7 @@ class TestPdbjCifPipelineRun:
             create_test_pdbj_cif_file(cif_path, [{"id": pdb_id}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -271,7 +271,7 @@ class TestPdbjCifPipelineRun:
             create_test_pdbj_cif_file(cif_path, [{"id": f"{i:03d}d"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -286,7 +286,7 @@ class TestTransformEntry:
     def test_with_entry_data(self, tmp_path: Path) -> None:
         """Transform entry with data."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)
@@ -301,7 +301,7 @@ class TestTransformEntry:
     def test_without_entry_data(self, tmp_path: Path) -> None:
         """Transform entry creates fallback when no data."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["pdbj-cif"]
+        config = settings.pipelines["pdbj"]
         schema_def = create_test_schema_def()
 
         pipeline = PdbjCifPipeline(settings, config, schema_def)

--- a/tests/test_prd_cif.py
+++ b/tests/test_prd_cif.py
@@ -1,4 +1,4 @@
-"""Tests for prd-cif pipeline."""
+"""Tests for prd pipeline (CIF format)."""
 
 import gzip
 from pathlib import Path
@@ -117,7 +117,7 @@ def create_test_settings(data_dir: Path) -> Settings:
     return Settings(
         rdb=RdbConfig(nworkers=2, constring="test"),
         pipelines={
-            "prd-cif": PipelineConfig(
+            "prd": PipelineConfig(
                 deffile="schemas/prd.def.yml",
                 data=str(data_dir),
             )
@@ -220,7 +220,7 @@ class TestFindCifFiles:
         create_test_prdcc_cif_file(prdcc_path, [{"id": "PRDCC_000001"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["prd-cif"]
+        config = settings.pipelines["prd"]
         schema_def = create_test_schema_def()
 
         pipeline = PrdCifPipeline(settings, config, schema_def)
@@ -235,7 +235,7 @@ class TestFindCifFiles:
         create_test_prd_cif_file(prd_path, [{"id": "PRD_000001"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["prd-cif"]
+        config = settings.pipelines["prd"]
         schema_def = create_test_schema_def()
 
         pipeline = PrdCifPipeline(settings, config, schema_def)
@@ -252,7 +252,7 @@ class TestFindCifFiles:
         create_test_prd_cif_file(prd_path, [{"id": "PRD_000001"}])
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["prd-cif"]
+        config = settings.pipelines["prd"]
         schema_def = create_test_schema_def()
 
         pipeline = PrdCifPipeline(settings, config, schema_def)
@@ -263,7 +263,7 @@ class TestFindCifFiles:
     def test_not_found(self, tmp_path: Path) -> None:
         """Return None when PRD CIF file not found."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["prd-cif"]
+        config = settings.pipelines["prd"]
         schema_def = create_test_schema_def()
 
         pipeline = PrdCifPipeline(settings, config, schema_def)
@@ -275,7 +275,7 @@ class TestFindCifFiles:
     def test_directory_not_exists(self, tmp_path: Path) -> None:
         """Return None when data directory doesn't exist."""
         settings = create_test_settings(tmp_path.joinpath("nonexistent"))
-        config = settings.pipelines["prd-cif"]
+        config = settings.pipelines["prd"]
         schema_def = create_test_schema_def()
 
         pipeline = PrdCifPipeline(settings, config, schema_def)
@@ -347,7 +347,7 @@ class TestPrdCifPipelineRun:
     def test_run_returns_empty_when_no_file(self, tmp_path: Path) -> None:
         """Run returns empty list when PRD CIF file not found."""
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["prd-cif"]
+        config = settings.pipelines["prd"]
         schema_def = create_test_schema_def()
 
         pipeline = PrdCifPipeline(settings, config, schema_def)
@@ -369,7 +369,7 @@ class TestPrdCifPipelineRun:
         )
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["prd-cif"]
+        config = settings.pipelines["prd"]
         schema_def = create_test_schema_def()
 
         pipeline = PrdCifPipeline(settings, config, schema_def)
@@ -386,7 +386,7 @@ class TestPrdCifPipelineRun:
         )
 
         settings = create_test_settings(tmp_path)
-        config = settings.pipelines["prd-cif"]
+        config = settings.pipelines["prd"]
         schema_def = create_test_schema_def()
 
         pipeline = PrdCifPipeline(settings, config, schema_def)


### PR DESCRIPTION
## Summary

- Make CIF the default format for dual-format pipelines (pdbj, cc, ccmodel, prd)
- mmJSON now requires `-json` suffix (pdbj-json, cc-json, ccmodel-json, prd-json)
- Legacy `-cif` names still work with deprecation warning for backward compatibility

## Changes

- **update.py/sync.py**: Updated dispatch logic and target names
- **utils.py**: New shared `resolve_legacy_aliases()` utility
- **cli.py**: Updated help text
- **test_commands.py**: 15 new tests for backward compatibility
- **Documentation**: Updated CLAUDE.md and README.md

## Test plan

- [x] All 89 tests pass (74 original + 15 new)
- [x] Lint and format checks pass
- [ ] Manual verification: `pixi run mine2 update pdbj --limit 5` (CIF default)
- [ ] Manual verification: `pixi run mine2 update pdbj-json --limit 5` (mmJSON)
- [ ] Manual verification: `pixi run mine2 update pdbj-cif --limit 5` (legacy with warning)