### PR TITLE
feat: Add plus data support for CIF pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,40 @@ For users who prefer mmJSON format, use the `-json` suffix:
 Legacy pipeline names (`pdbj-cif`, `cc-cif`, etc.) are still accepted but deprecated.
 They will emit a warning and run the corresponding CIF pipeline.
 
+### Plus Data Support (pdbj pipeline)
+
+Both CIF and mmJSON pdbj pipelines can merge PDBj-specific plus data when configured:
+
+```yaml
+# config.yml
+pipelines:
+  pdbj:
+    deffile: ${CWD}schemas/pdbj.def.yml
+    data: /path/to/mmCIF/             # CIF files
+    data-plus: /path/to/mmjson-plus/  # Plus data (mmJSON format)
+```
+
+Plus data adds PDBj-specific annotations:
+- `gene_ontology_pdbmlplus` - Gene Ontology (GO) annotations
+- `struct_ref_pdbmlplus` - Additional UniProt reference data
+- `citation_pdbmlplus`, `refine_pdbmlplus`, etc. (18 total categories)
+
+| Configuration | CIF Pipeline | mmJSON Pipeline |
+|---------------|--------------|-----------------|
+| Without `data-plus` | Standard mmCIF only | `mmjson-noatom` only |
+| With `data-plus` | CIF + plus data merged | `mmjson-noatom` + plus merged |
+
+### Unsupported Pipelines
+
+The following data types have schema definitions but are **not implemented** as pipelines:
+
+| Schema | Status | Notes |
+|--------|--------|-------|
+| ihm | Not supported | Integrative/hybrid methods (I/HM) data |
+| emdb | Not supported | Electron Microscopy Data Bank |
+
+These may be added in future versions if needed.
+
 ## Database Management
 
 ```bash

--- a/src/mine2/config.py
+++ b/src/mine2/config.py
@@ -46,6 +46,8 @@ class PipelineConfig(BaseModel):
         default=None, alias="data-plus", description="Additional data directory"
     )
 
+    model_config = {"populate_by_name": True}
+
 
 class Settings(BaseModel):
     """Application settings."""

--- a/src/mine2/pipelines/pdbj.py
+++ b/src/mine2/pipelines/pdbj.py
@@ -203,8 +203,10 @@ class PdbjCifPipeline(BasePipeline):
 
         CifWalk is C++ native and faster than rglob for large directories.
         Automatically handles both .cif and .cif.gz files.
+        Also pairs with plus data (mmJSON) if configured.
         """
         data_dir = Path(self.config.data)
+        plus_dir = Path(self.config.data_plus) if self.config.data_plus else None
 
         if not data_dir.exists():
             console.print(f"  [red]Data directory not found: {data_dir}[/red]")
@@ -214,7 +216,30 @@ class PdbjCifPipeline(BasePipeline):
         for filepath_str in gemmi.CifWalk(str(data_dir)):
             filepath = Path(filepath_str)
             entry_id = self.extract_entry_id(filepath)
-            jobs.append(Job(entry_id=entry_id, filepath=filepath))
+
+            # Look for plus file: {entry_id}-plus.json.gz
+            plus_path = None
+            if plus_dir and plus_dir.exists():
+                candidate = plus_dir.joinpath(f"{entry_id}-plus.json.gz")
+                # Validate path is within plus_dir to prevent path traversal
+                try:
+                    resolved = candidate.resolve()
+                    if (
+                        resolved.is_relative_to(plus_dir.resolve())
+                        and resolved.exists()
+                    ):
+                        plus_path = candidate
+                except (ValueError, OSError):
+                    # is_relative_to raises ValueError if not relative
+                    pass
+
+            jobs.append(
+                Job(
+                    entry_id=entry_id,
+                    filepath=filepath,
+                    extra={"plus_path": plus_path},
+                )
+            )
 
             if limit and len(jobs) >= limit:
                 break
@@ -231,6 +256,12 @@ class PdbjCifPipeline(BasePipeline):
         try:
             # Parse CIF file (row-oriented, same format as mmJSON)
             data = parse_cif_file(job.filepath)
+
+            # Merge with plus data if available (mmJSON format)
+            plus_path = job.extra.get("plus_path") if job.extra else None
+            if plus_path:
+                plus_data = parse_mmjson_file(plus_path)
+                data = merge_data(data, plus_data)
 
             # Transform and load
             rows_inserted = 0

--- a/tests/test_pdbj_cif.py
+++ b/tests/test_pdbj_cif.py
@@ -368,3 +368,273 @@ class TestRealPdbFixtures:
         ]
         for cat in expected_categories:
             assert cat in data, f"Missing category: {cat}"
+
+
+def create_test_settings_with_plus(data_dir: Path, plus_dir: Path) -> Settings:
+    """Create test settings with plus data directory."""
+    return Settings(
+        rdb=RdbConfig(nworkers=2, constring="test"),
+        pipelines={
+            "pdbj": PipelineConfig(
+                deffile="schemas/pdbj.def.yml",
+                data=str(data_dir),
+                data_plus=str(plus_dir),
+            )
+        },
+    )
+
+
+def create_test_plus_file(path: Path, entry_id: str, extra_categories: dict) -> None:
+    """Create a test plus data file (mmJSON format).
+
+    mmJSON is column-oriented:
+    {"data_XXX": {"category": {"col1": [val1, val2], "col2": [val1, val2]}}}
+
+    Args:
+        path: Path to write the file (should end with -plus.json.gz)
+        entry_id: PDB entry ID (e.g., "100d")
+        extra_categories: Dict of category name to list of row dicts
+    """
+    import json
+
+    # Build mmJSON structure (column-oriented)
+    block_data = {}
+    for cat, rows in extra_categories.items():
+        if not rows:
+            continue
+        # Convert row-oriented to column-oriented
+        columns = list(rows[0].keys())
+        col_data = {col: [row.get(col) for row in rows] for col in columns}
+        block_data[cat] = col_data
+
+    data = {"data_" + entry_id.upper(): block_data}
+
+    content = json.dumps(data)
+    with gzip.open(path, "wt") as f:
+        f.write(content)
+
+
+def create_test_schema_def_with_plus() -> SchemaDef:
+    """Create test schema definition with plus data tables."""
+    return SchemaDef(
+        schema_name="pdbj",
+        primary_key="pdbid",
+        tables=[
+            TableDef(
+                name="entry",
+                columns=[("pdbid", "TEXT"), ("id", "TEXT")],
+                primary_key=["pdbid", "id"],
+            ),
+            TableDef(
+                name="cell",
+                columns=[
+                    ("pdbid", "TEXT"),
+                    ("entry_id", "TEXT"),
+                    ("length_a", "REAL"),
+                    ("length_b", "REAL"),
+                    ("length_c", "REAL"),
+                ],
+                primary_key=["pdbid"],
+            ),
+            TableDef(
+                name="gene_ontology_pdbmlplus",
+                columns=[
+                    ("pdbid", "TEXT"),
+                    ("goid", "TEXT"),
+                    ("name", "TEXT"),
+                ],
+                primary_key=["pdbid", "goid"],
+            ),
+        ],
+    )
+
+
+class TestFindJobsWithPlusData:
+    """Tests for PdbjCifPipeline.find_jobs() with plus data."""
+
+    def test_finds_plus_files_when_configured(self, tmp_path: Path) -> None:
+        """Find jobs includes plus_path when plus directory is configured."""
+        # Create CIF data directory
+        cif_dir = tmp_path / "mmCIF"
+        cif_dir.mkdir()
+        cif_path = cif_dir / "100d.cif.gz"
+        create_test_pdbj_cif_file(cif_path, [{"id": "100d"}])
+
+        # Create plus data directory
+        plus_dir = tmp_path / "mmjson-plus"
+        plus_dir.mkdir()
+        plus_path = plus_dir / "100d-plus.json.gz"
+        create_test_plus_file(
+            plus_path,
+            "100d",
+            {"gene_ontology_pdbmlplus": [{"goid": "GO:0001234", "name": "test"}]},
+        )
+
+        settings = create_test_settings_with_plus(cif_dir, plus_dir)
+        config = settings.pipelines["pdbj"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PdbjCifPipeline(settings, config, schema_def)
+        jobs = pipeline.find_jobs()
+
+        assert len(jobs) == 1
+        assert jobs[0].entry_id == "100d"
+        assert jobs[0].extra is not None
+        assert jobs[0].extra.get("plus_path") == plus_path
+
+    def test_plus_path_none_when_file_not_exists(self, tmp_path: Path) -> None:
+        """Plus path is None when plus file doesn't exist."""
+        # Create CIF data directory
+        cif_dir = tmp_path / "mmCIF"
+        cif_dir.mkdir()
+        cif_path = cif_dir / "100d.cif.gz"
+        create_test_pdbj_cif_file(cif_path, [{"id": "100d"}])
+
+        # Create empty plus data directory (no matching file)
+        plus_dir = tmp_path / "mmjson-plus"
+        plus_dir.mkdir()
+
+        settings = create_test_settings_with_plus(cif_dir, plus_dir)
+        config = settings.pipelines["pdbj"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PdbjCifPipeline(settings, config, schema_def)
+        jobs = pipeline.find_jobs()
+
+        assert len(jobs) == 1
+        assert jobs[0].extra is not None
+        assert jobs[0].extra.get("plus_path") is None
+
+    def test_plus_path_none_when_plus_dir_not_configured(self, tmp_path: Path) -> None:
+        """Plus path is None when plus directory is not configured."""
+        # Create CIF data directory
+        cif_dir = tmp_path / "mmCIF"
+        cif_dir.mkdir()
+        cif_path = cif_dir / "100d.cif.gz"
+        create_test_pdbj_cif_file(cif_path, [{"id": "100d"}])
+
+        # No plus directory configured
+        settings = create_test_settings(cif_dir)
+        config = settings.pipelines["pdbj"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PdbjCifPipeline(settings, config, schema_def)
+        jobs = pipeline.find_jobs()
+
+        assert len(jobs) == 1
+        assert jobs[0].extra is not None
+        assert jobs[0].extra.get("plus_path") is None
+
+    def test_finds_partial_plus_files(self, tmp_path: Path) -> None:
+        """Some entries have plus files, some don't."""
+        # Create CIF data directory with multiple entries
+        cif_dir = tmp_path / "mmCIF"
+        cif_dir.mkdir()
+        for pdb_id in ["100d", "101d", "102d"]:
+            cif_path = cif_dir / f"{pdb_id}.cif.gz"
+            create_test_pdbj_cif_file(cif_path, [{"id": pdb_id}])
+
+        # Create plus directory with only one matching file
+        plus_dir = tmp_path / "mmjson-plus"
+        plus_dir.mkdir()
+        plus_path = plus_dir / "100d-plus.json.gz"
+        create_test_plus_file(
+            plus_path,
+            "100d",
+            {"gene_ontology_pdbmlplus": [{"goid": "GO:0001234", "name": "test"}]},
+        )
+
+        settings = create_test_settings_with_plus(cif_dir, plus_dir)
+        config = settings.pipelines["pdbj"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PdbjCifPipeline(settings, config, schema_def)
+        jobs = pipeline.find_jobs()
+
+        assert len(jobs) == 3
+        plus_paths = {j.entry_id: j.extra.get("plus_path") for j in jobs}
+        assert plus_paths["100d"] == plus_path
+        assert plus_paths["101d"] is None
+        assert plus_paths["102d"] is None
+
+
+class TestProcessJobWithPlusData:
+    """Tests for PdbjCifPipeline.process_job() with plus data merging."""
+
+    def test_merges_plus_data_into_cif_data(self, tmp_path: Path) -> None:
+        """Plus data categories are merged into CIF data."""
+        from unittest.mock import patch
+
+        from mine2.db.loader import Job
+
+        # Create CIF file
+        cif_dir = tmp_path / "mmCIF"
+        cif_dir.mkdir()
+        cif_path = cif_dir / "100d.cif.gz"
+        create_test_pdbj_cif_file(cif_path, [{"id": "100d"}])
+
+        # Create plus file with extra category
+        plus_dir = tmp_path / "mmjson-plus"
+        plus_dir.mkdir()
+        plus_path = plus_dir / "100d-plus.json.gz"
+        create_test_plus_file(
+            plus_path,
+            "100d",
+            {"gene_ontology_pdbmlplus": [{"goid": "GO:0001234", "name": "test"}]},
+        )
+
+        settings = create_test_settings_with_plus(cif_dir, plus_dir)
+        config = settings.pipelines["pdbj"]
+        schema_def = create_test_schema_def_with_plus()
+
+        pipeline = PdbjCifPipeline(settings, config, schema_def)
+        job = Job(
+            entry_id="100d",
+            filepath=cif_path,
+            extra={"plus_path": plus_path},
+        )
+
+        # Mock bulk_upsert to capture what gets loaded
+        with patch("mine2.pipelines.pdbj.bulk_upsert") as mock_upsert:
+            mock_upsert.return_value = (1, 0)
+            result = pipeline.process_job(job, schema_def, "test_conninfo")
+
+            assert result.success
+            # Verify gene_ontology_pdbmlplus was loaded (from plus data)
+            calls = mock_upsert.call_args_list
+            table_names = [call[0][2] for call in calls]  # Third arg is table name
+            assert "gene_ontology_pdbmlplus" in table_names
+
+    def test_works_without_plus_data(self, tmp_path: Path) -> None:
+        """Process job works when plus_path is None."""
+        from unittest.mock import patch
+
+        from mine2.db.loader import Job
+
+        # Create CIF file only (no plus data)
+        cif_dir = tmp_path / "mmCIF"
+        cif_dir.mkdir()
+        cif_path = cif_dir / "100d.cif.gz"
+        create_test_pdbj_cif_file(cif_path, [{"id": "100d"}])
+
+        settings = create_test_settings(cif_dir)
+        config = settings.pipelines["pdbj"]
+        schema_def = create_test_schema_def()
+
+        pipeline = PdbjCifPipeline(settings, config, schema_def)
+        job = Job(
+            entry_id="100d",
+            filepath=cif_path,
+            extra={"plus_path": None},
+        )
+
+        # Mock bulk_upsert
+        with patch("mine2.pipelines.pdbj.bulk_upsert") as mock_upsert:
+            mock_upsert.return_value = (1, 0)
+            result = pipeline.process_job(job, schema_def, "test_conninfo")
+
+            assert result.success
+            # Should still load entry and cell tables
+            calls = mock_upsert.call_args_list
+            table_names = [call[0][2] for call in calls]
+            assert "entry" in table_names


### PR DESCRIPTION
## Summary
- CIF pipelines (pdbj) now support merging plus data when `data-plus` is configured
- Plus data adds PDBj-specific annotations (gene_ontology_pdbmlplus, etc.)
- Document ihm/emdb as unsupported pipelines

## Changes
### Code
- **`src/mine2/pipelines/pdbj.py`**: Modified `PdbjCifPipeline.find_jobs()` to find plus files, `process_job()` to merge them
- **`src/mine2/config.py`**: Added `populate_by_name` to `PipelineConfig` for proper alias handling

### Tests
- **`tests/test_pdbj_cif.py`**: Added `TestFindJobsWithPlusData` class with 4 tests

### Documentation
- **`README.md`**: Added Plus Data Support section and Unsupported Pipelines section

## Test plan
- [x] All 112 tests pass
- [x] `pixi run check` passes (except known ty LiteralString warning)

## Notes
Supersedes PR #22 (now closed).