### PR TITLE
fix: Change db_accession column type from text[] to text

### DIFF
--- a/schemas/pdbj.def.yml
+++ b/schemas/pdbj.def.yml
@@ -10037,7 +10037,7 @@ tables:
       - - db_name
         - text
       - - db_accession
-        - text[]
+        - text
     primary_key:
       - pdbid
       - db_name
@@ -10057,7 +10057,7 @@ tables:
       - - db_name
         - text
       - - db_accession
-        - text[]
+        - text
     primary_key:
       - pdbid
       - entity_id


### PR DESCRIPTION
## Summary

- Fix `malformed array literal` error in pdbj/pdbj-json pipelines
- Change column type from `text[]` to `text` for:
  - `link_entry_pdbjplus.db_accession`
  - `link_entity_pdbjplus.db_accession`

## Root Cause

The plus data (mmjson-plus) contains plain strings like `"101d-A,B"` for `db_accession`, but the schema incorrectly defined it as `text[]`. PostgreSQL expected array format `{101d-A,B}` but received a plain string.

## Migration

For existing databases with the old schema:

```sql
ALTER TABLE pdbj.link_entry_pdbjplus ALTER COLUMN db_accession TYPE text;
ALTER TABLE pdbj.link_entity_pdbjplus ALTER COLUMN db_accession TYPE text;
```

## Test Plan

- [x] `pixi run test` passes (146 tests)
- [x] `pixi run mine2 update pdbj --limit 10` succeeds
- [x] `pixi run mine2 update pdbj-json --limit 10` succeeds