### PR TITLE
fix: Add array coercion for text[]/integer[] columns

### DIFF
--- a/src/mine2/pipelines/base.py
+++ b/src/mine2/pipelines/base.py
@@ -13,6 +13,48 @@ from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, run_loader
 console = Console()
 
 
+def _coerce_array_value(value: Any, col_type: str) -> Any:
+    """Coerce a value to array type if the column expects an array.
+
+    Matches original mine2updater behavior (enforceStringArray):
+    - If the column type ends with '[]' and the value is not a list, wrap it in a list
+    - Convert elements to strings for text[], integers for integer[]
+
+    Args:
+        value: The value to coerce
+        col_type: The column type from schema (e.g., 'text[]', 'integer[]')
+
+    Returns:
+        Coerced value (as list if array column, original otherwise)
+    """
+    if value is None:
+        return None
+
+    if not col_type.endswith("[]"):
+        return value
+
+    # Wrap non-list values in a list
+    if not isinstance(value, list):
+        value = [value]
+
+    # Convert elements based on array type
+    if col_type == "text[]":
+        return [str(v) if v is not None else None for v in value]
+    elif col_type == "integer[]":
+        result = []
+        for v in value:
+            if v is None:
+                result.append(None)
+            else:
+                try:
+                    result.append(int(v))
+                except (ValueError, TypeError):
+                    result.append(None)
+        return result
+
+    return value
+
+
 def transform_category(
     rows: list[dict[str, Any]],
     table: TableDef,
@@ -37,8 +79,9 @@ def transform_category(
     if not rows:
         return []
 
-    # Get column names from schema (preserving order)
+    # Get column names and types from schema
     schema_columns = [col_name for col_name, _ in table.columns]
+    column_types = {col_name: col_type for col_name, col_type in table.columns}
     valid_columns = set(schema_columns)
 
     # First pass: collect all columns that appear in any row
@@ -72,7 +115,10 @@ def transform_category(
         for col in final_columns:
             if col == pk_col:
                 continue
-            transformed_row[col] = normalized_row.get(col)
+            value = normalized_row.get(col)
+            # Coerce to array type if needed
+            col_type = column_types.get(col, "text")
+            transformed_row[col] = _coerce_array_value(value, col_type)
 
         result.append(transformed_row)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,95 @@
+"""Tests for base pipeline functionality."""
+
+import pytest
+
+from mine2.pipelines.base import _coerce_array_value, transform_category
+from mine2.db.loader import TableDef
+
+
+class TestCoerceArrayValue:
+    """Tests for _coerce_array_value function."""
+
+    def test_none_value_returns_none(self):
+        assert _coerce_array_value(None, "text[]") is None
+        assert _coerce_array_value(None, "integer[]") is None
+        assert _coerce_array_value(None, "text") is None
+
+    def test_non_array_column_returns_unchanged(self):
+        assert _coerce_array_value("hello", "text") == "hello"
+        assert _coerce_array_value(123, "integer") == 123
+        assert _coerce_array_value(["a", "b"], "text") == ["a", "b"]
+
+    def test_text_array_wraps_string(self):
+        # String value should be wrapped in array
+        result = _coerce_array_value("101d-A,B", "text[]")
+        assert result == ["101d-A,B"]
+
+    def test_text_array_preserves_list(self):
+        # List value should be preserved
+        result = _coerce_array_value(["a", "b", "c"], "text[]")
+        assert result == ["a", "b", "c"]
+
+    def test_text_array_converts_elements_to_strings(self):
+        # Elements should be converted to strings
+        result = _coerce_array_value([1, 2, 3], "text[]")
+        assert result == ["1", "2", "3"]
+
+    def test_text_array_handles_none_elements(self):
+        result = _coerce_array_value(["a", None, "b"], "text[]")
+        assert result == ["a", None, "b"]
+
+    def test_integer_array_wraps_integer(self):
+        result = _coerce_array_value(42, "integer[]")
+        assert result == [42]
+
+    def test_integer_array_converts_strings_to_ints(self):
+        result = _coerce_array_value(["1", "2", "3"], "integer[]")
+        assert result == [1, 2, 3]
+
+    def test_integer_array_handles_invalid_values(self):
+        result = _coerce_array_value(["1", "invalid", "3"], "integer[]")
+        assert result == [1, None, 3]
+
+
+class TestTransformCategory:
+    """Tests for transform_category function."""
+
+    @pytest.fixture
+    def table_with_arrays(self):
+        """Table definition with array columns."""
+        return TableDef(
+            name="test_table",
+            columns=[
+                ("pdbid", "text"),
+                ("name", "text"),
+                ("tags", "text[]"),
+                ("counts", "integer[]"),
+            ],
+            primary_key=["pdbid"],
+        )
+
+    def test_empty_rows_returns_empty(self, table_with_arrays):
+        result = transform_category([], table_with_arrays, "101d", "pdbid")
+        assert result == []
+
+    def test_basic_transform(self, table_with_arrays):
+        rows = [{"name": "test"}]
+        result = transform_category(rows, table_with_arrays, "101d", "pdbid")
+        assert len(result) == 1
+        assert result[0]["pdbid"] == "101d"
+        assert result[0]["name"] == "test"
+
+    def test_array_column_wraps_string(self, table_with_arrays):
+        rows = [{"name": "test", "tags": "single-tag"}]
+        result = transform_category(rows, table_with_arrays, "101d", "pdbid")
+        assert result[0]["tags"] == ["single-tag"]
+
+    def test_array_column_preserves_list(self, table_with_arrays):
+        rows = [{"name": "test", "tags": ["tag1", "tag2"]}]
+        result = transform_category(rows, table_with_arrays, "101d", "pdbid")
+        assert result[0]["tags"] == ["tag1", "tag2"]
+
+    def test_integer_array_column(self, table_with_arrays):
+        rows = [{"name": "test", "counts": "42"}]
+        result = transform_category(rows, table_with_arrays, "101d", "pdbid")
+        assert result[0]["counts"] == [42]


### PR DESCRIPTION
## Summary

- Port `enforceStringArray()` behavior from original mine2updater to handle array columns correctly
- Non-array values (scalars) are automatically wrapped in arrays when the schema defines a column as `text[]` or `integer[]`
- Elements are converted to appropriate types (str for text[], int for integer[])

## Problem

The `malformed array literal: "101d-A,B"` error occurred because plus data contains scalar strings for columns defined as `text[]` in the schema (e.g., `link_entry_pdbjplus.db_accession`).

PostgreSQL expected array format `{101d-A,B}` but received a plain string.

## Solution

Added `_coerce_array_value()` function in `base.py` that matches the original mine2updater's `enforceStringArray()` behavior:
- Check column type from schema
- If column ends with `[]` and value is not a list, wrap it in a list
- Convert elements to appropriate type (string or integer)

This approach preserves the schema (which comes via rsync) and handles the type coercion at the application layer.

## Test plan

- [x] Added unit tests for `_coerce_array_value()` function (14 tests)
- [x] Added unit tests for `transform_category()` with array columns
- [x] Verified `pdbj` pipeline runs successfully with 10 entries
- [x] Verified `pdbj-json` pipeline runs successfully with 10 entries
- [x] All 160 tests pass