### PR TITLE
feat: Add mmJSON query and array utility functions (Phase 2)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -7,7 +7,7 @@ Complete the port of functionality from original mine2updater (JavaScript) to mi
 
 | Phase | Name | Priority | Complexity | Status |
 |-------|------|----------|------------|--------|
-| 1 | [Type Coercion](phase-1-type-coercion.md) | HIGH | Low | ⬜ Not Started |
+| 1 | [Type Coercion](phase-1-type-coercion.md) | HIGH | Low | ✅ Complete |
 | 2 | [mmJSON Utils](phase-2-mmjson-utils.md) | MEDIUM | Low | ⬜ Not Started |
 | 3 | [Delta Updates](phase-3-delta-updates.md) | CRITICAL | High | ⬜ Not Started |
 | 4 | [Missing Pipelines](phase-4-missing-pipelines.md) | HIGH | Medium | ⬜ Not Started |
@@ -61,7 +61,7 @@ Phase 5 (Advanced Features) ← As needed
 
 Update this section as phases complete:
 
-- [ ] Phase 1 complete
+- [x] Phase 1 complete
 - [ ] Phase 2 complete
 - [ ] Phase 3 complete
 - [ ] Phase 4 complete

--- a/src/mine2/parsers/mmjson.py
+++ b/src/mine2/parsers/mmjson.py
@@ -1,11 +1,16 @@
 """mmJSON utilities for PDBj data files.
 
 Note: Parsing is now handled by parsers/cif.py using gemmi.
-This module provides utility functions for column name normalization and data merging.
+This module provides utility functions for column name normalization, data merging,
+and querying mmJSON data structures.
+
+Ported from original mine2updater rdb-helper.js.
 """
 
 import re
-from typing import Any
+from typing import Any, TypeVar
+
+T = TypeVar("T")
 
 
 def normalize_column_name(name: str) -> str:
@@ -73,3 +78,169 @@ def merge_data(base: dict[str, Any], plus: dict[str, Any]) -> dict[str, Any]:
             result[category] = merged_rows
 
     return result
+
+
+# =============================================================================
+# Query Functions
+# Ported from original mine2updater rdb-helper.js
+# =============================================================================
+
+
+def mmjson_at(
+    rows: list[dict[str, Any]],
+    get_field: str,
+    cond_field: str,
+    cond_val: Any,
+) -> list[Any]:
+    """Get values from rows where a condition field matches a value.
+
+    Filters rows where cond_field == cond_val and returns the get_field values.
+
+    Args:
+        rows: List of row dicts (from a category)
+        get_field: Field name to retrieve values from
+        cond_field: Field name to check condition against
+        cond_val: Value to match in cond_field
+
+    Returns:
+        List of get_field values from matching rows
+
+    Example:
+        >>> rows = [{"type": "SMILES", "value": "CCO"}, {"type": "InChI", "value": "..."}]
+        >>> mmjson_at(rows, "value", "type", "SMILES")
+        ["CCO"]
+    """
+    if not rows:
+        return []
+    result = []
+    for row in rows:
+        if row.get(cond_field) == cond_val and get_field in row:
+            result.append(row[get_field])
+    return result
+
+
+def mmjson_at_ic(
+    rows: list[dict[str, Any]],
+    get_field: str,
+    cond_field: str,
+    cond_val: str,
+) -> list[Any]:
+    """Case-insensitive version of mmjson_at.
+
+    Args:
+        rows: List of row dicts (from a category)
+        get_field: Field name to retrieve values from
+        cond_field: Field name to check condition against
+        cond_val: Value to match (case-insensitive)
+
+    Returns:
+        List of get_field values from matching rows
+    """
+    if not rows:
+        return []
+    cond_val_lower = cond_val.lower()
+    result = []
+    for row in rows:
+        field_val = row.get(cond_field)
+        if field_val is not None and str(field_val).lower() == cond_val_lower:
+            if get_field in row:
+                result.append(row[get_field])
+    return result
+
+
+def mmjson_get(
+    rows: list[dict[str, Any]],
+    field: str,
+    index: int | None = None,
+) -> Any:
+    """Safely get field values from rows.
+
+    Args:
+        rows: List of row dicts (from a category)
+        field: Field name to retrieve
+        index: Optional row index. If None, returns all values.
+
+    Returns:
+        - If index is specified: value at that row, or None if not found
+        - If index is None: list of all values for that field
+    """
+    if not rows:
+        return None if index is not None else []
+
+    if index is not None:
+        if 0 <= index < len(rows):
+            return rows[index].get(field)
+        return None
+
+    return [row.get(field) for row in rows]
+
+
+def get_object_value(obj: dict[str, Any], field: str, default: T) -> Any | T:
+    """Safely get a value from a dict with a default.
+
+    Args:
+        obj: Dictionary to get value from
+        field: Key to look up
+        default: Default value if key not found
+
+    Returns:
+        Value if found, otherwise default
+    """
+    return obj.get(field, default)
+
+
+# =============================================================================
+# Array Utility Functions
+# =============================================================================
+
+
+def clean_array(array: list[Any]) -> list[Any]:
+    """Remove nulls, empty strings, duplicates, and sort the array.
+
+    Matches original mine2updater cleanArray():
+    - Remove None/null values
+    - Remove empty strings
+    - Remove duplicates (preserving first occurrence)
+    - Sort the result
+
+    Args:
+        array: Input list
+
+    Returns:
+        Cleaned and sorted list
+
+    Example:
+        >>> clean_array(["b", None, "a", "b", "", "c"])
+        ["a", "b", "c"]
+    """
+    # Remove None, empty strings, and deduplicate using dict (preserves order in Python 3.7+)
+    seen: dict[Any, None] = {}
+    for item in array:
+        if item is not None and item != "":
+            seen[item] = None
+
+    # Sort - handle mixed types by converting to string for comparison
+    result = list(seen.keys())
+    try:
+        result.sort()
+    except TypeError:
+        # Mixed types that can't be compared - sort by string representation
+        result.sort(key=str)
+
+    return result
+
+
+def remove_null(array: list[Any]) -> list[Any]:
+    """Remove null/None values from an array.
+
+    Args:
+        array: Input list
+
+    Returns:
+        List with None values removed
+
+    Example:
+        >>> remove_null(["a", None, "b", None])
+        ["a", "b"]
+    """
+    return [v for v in array if v is not None]

--- a/tests/test_mmjson.py
+++ b/tests/test_mmjson.py
@@ -1,0 +1,246 @@
+"""Tests for mmJSON utilities."""
+
+import pytest
+
+from mine2.parsers.mmjson import (
+    clean_array,
+    get_object_value,
+    merge_data,
+    mmjson_at,
+    mmjson_at_ic,
+    mmjson_get,
+    normalize_column_name,
+    remove_null,
+)
+
+
+class TestNormalizeColumnName:
+    """Tests for normalize_column_name function."""
+
+    def test_single_bracket(self):
+        assert normalize_column_name("column[0]") == "column0"
+
+    def test_double_bracket(self):
+        assert (
+            normalize_column_name("fract_transf_matrix[1][1]")
+            == "fract_transf_matrix11"
+        )
+
+    def test_no_brackets(self):
+        assert normalize_column_name("simple_name") == "simple_name"
+
+    def test_multiple_digits(self):
+        assert normalize_column_name("data[12][34]") == "data1234"
+
+
+class TestMergeData:
+    """Tests for merge_data function."""
+
+    def test_base_only(self):
+        base = {"category": [{"a": 1}]}
+        plus = {}
+        result = merge_data(base, plus)
+        assert result == {"category": [{"a": 1}]}
+
+    def test_plus_only(self):
+        base = {}
+        plus = {"category": [{"b": 2}]}
+        result = merge_data(base, plus)
+        assert result == {"category": [{"b": 2}]}
+
+    def test_merge_rows(self):
+        base = {"cat": [{"a": 1, "b": 2}]}
+        plus = {"cat": [{"b": 3, "c": 4}]}
+        result = merge_data(base, plus)
+        # Plus takes precedence for 'b'
+        assert result == {"cat": [{"a": 1, "b": 3, "c": 4}]}
+
+    def test_metadata_plus_precedence(self):
+        base = {"_block_name": "base"}
+        plus = {"_block_name": "plus"}
+        result = merge_data(base, plus)
+        assert result["_block_name"] == "plus"
+
+
+class TestMmjsonAt:
+    """Tests for mmjson_at function."""
+
+    def test_empty_rows(self):
+        assert mmjson_at([], "value", "type", "SMILES") == []
+
+    def test_no_match(self):
+        rows = [{"type": "InChI", "value": "xyz"}]
+        assert mmjson_at(rows, "value", "type", "SMILES") == []
+
+    def test_single_match(self):
+        rows = [
+            {"type": "SMILES", "value": "CCO"},
+            {"type": "InChI", "value": "xyz"},
+        ]
+        result = mmjson_at(rows, "value", "type", "SMILES")
+        assert result == ["CCO"]
+
+    def test_multiple_matches(self):
+        rows = [
+            {"type": "SMILES", "value": "CCO"},
+            {"type": "SMILES", "value": "CC"},
+            {"type": "InChI", "value": "xyz"},
+        ]
+        result = mmjson_at(rows, "value", "type", "SMILES")
+        assert result == ["CCO", "CC"]
+
+    def test_missing_get_field_skipped(self):
+        rows = [
+            {"type": "SMILES"},  # No 'value' field
+            {"type": "SMILES", "value": "CCO"},
+        ]
+        # Missing field should be skipped (consistent with mmjson_at_ic)
+        result = mmjson_at(rows, "value", "type", "SMILES")
+        assert result == ["CCO"]
+
+
+class TestMmjsonAtIc:
+    """Tests for mmjson_at_ic function (case-insensitive)."""
+
+    def test_empty_rows(self):
+        assert mmjson_at_ic([], "value", "type", "SMILES") == []
+
+    def test_case_insensitive_match(self):
+        rows = [
+            {"type": "smiles", "value": "CCO"},
+            {"type": "SMILES", "value": "CC"},
+            {"type": "Smiles", "value": "CCC"},
+        ]
+        result = mmjson_at_ic(rows, "value", "type", "SMILES")
+        assert result == ["CCO", "CC", "CCC"]
+
+    def test_no_match(self):
+        rows = [{"type": "InChI", "value": "xyz"}]
+        assert mmjson_at_ic(rows, "value", "type", "SMILES") == []
+
+    def test_missing_get_field_skipped(self):
+        rows = [
+            {"type": "SMILES"},  # No 'value' field
+            {"type": "SMILES", "value": "CCO"},
+        ]
+        # Missing field should be skipped, not raise error
+        result = mmjson_at_ic(rows, "value", "type", "SMILES")
+        assert result == ["CCO"]
+
+    def test_none_cond_field_skipped(self):
+        rows = [
+            {"type": None, "value": "CCO"},
+            {"type": "SMILES", "value": "CC"},
+        ]
+        result = mmjson_at_ic(rows, "value", "type", "SMILES")
+        assert result == ["CC"]
+
+
+class TestMmjsonGet:
+    """Tests for mmjson_get function."""
+
+    def test_empty_rows_no_index(self):
+        assert mmjson_get([], "field") == []
+
+    def test_empty_rows_with_index(self):
+        assert mmjson_get([], "field", 0) is None
+
+    def test_get_all_values(self):
+        rows = [{"a": 1}, {"a": 2}, {"a": 3}]
+        result = mmjson_get(rows, "a")
+        assert result == [1, 2, 3]
+
+    def test_get_value_at_index(self):
+        rows = [{"a": 1}, {"a": 2}, {"a": 3}]
+        assert mmjson_get(rows, "a", 0) == 1
+        assert mmjson_get(rows, "a", 1) == 2
+        assert mmjson_get(rows, "a", 2) == 3
+
+    def test_index_out_of_range(self):
+        rows = [{"a": 1}]
+        assert mmjson_get(rows, "a", 10) is None
+
+    def test_negative_index_out_of_range(self):
+        rows = [{"a": 1}]
+        assert mmjson_get(rows, "a", -1) is None
+
+    def test_missing_field_returns_none(self):
+        rows = [{"a": 1}, {"b": 2}]
+        result = mmjson_get(rows, "a")
+        assert result == [1, None]
+
+
+class TestGetObjectValue:
+    """Tests for get_object_value function."""
+
+    def test_field_exists(self):
+        obj = {"a": 1, "b": 2}
+        assert get_object_value(obj, "a", 0) == 1
+
+    def test_field_missing_returns_default(self):
+        obj = {"a": 1}
+        assert get_object_value(obj, "b", 99) == 99
+
+    def test_default_can_be_any_type(self):
+        obj = {}
+        assert get_object_value(obj, "x", []) == []
+        assert get_object_value(obj, "x", None) is None
+        assert get_object_value(obj, "x", "default") == "default"
+
+
+class TestCleanArray:
+    """Tests for clean_array function."""
+
+    def test_empty_array(self):
+        assert clean_array([]) == []
+
+    def test_removes_none(self):
+        assert clean_array([1, None, 2]) == [1, 2]
+
+    def test_removes_empty_string(self):
+        assert clean_array(["a", "", "b"]) == ["a", "b"]
+
+    def test_removes_duplicates(self):
+        assert clean_array(["a", "b", "a", "c", "b"]) == ["a", "b", "c"]
+
+    def test_sorts_result(self):
+        assert clean_array(["c", "a", "b"]) == ["a", "b", "c"]
+
+    def test_combined(self):
+        result = clean_array(["b", None, "a", "b", "", "c", None])
+        assert result == ["a", "b", "c"]
+
+    def test_numeric_values(self):
+        result = clean_array([3, 1, 2, 1, None, 3])
+        assert result == [1, 2, 3]
+
+    def test_mixed_types_sortable(self):
+        # Strings only - should sort
+        result = clean_array(["z", "a", "m"])
+        assert result == ["a", "m", "z"]
+
+
+class TestRemoveNull:
+    """Tests for remove_null function."""
+
+    def test_empty_array(self):
+        assert remove_null([]) == []
+
+    def test_no_nulls(self):
+        assert remove_null([1, 2, 3]) == [1, 2, 3]
+
+    def test_removes_none(self):
+        assert remove_null([1, None, 2, None, 3]) == [1, 2, 3]
+
+    def test_all_none(self):
+        assert remove_null([None, None]) == []
+
+    def test_preserves_empty_string(self):
+        # Unlike clean_array, remove_null only removes None
+        assert remove_null(["a", "", "b"]) == ["a", "", "b"]
+
+    def test_preserves_zero(self):
+        assert remove_null([0, None, 1]) == [0, 1]
+
+    def test_preserves_false(self):
+        assert remove_null([True, None, False]) == [True, False]


### PR DESCRIPTION
## Summary

Port utility functions from original mine2updater `rdb-helper.js` for querying mmJSON data and array manipulation.

### Query Functions

| Function | Description |
|----------|-------------|
| `mmjson_at()` | Filter rows by condition field, return get_field values |
| `mmjson_at_ic()` | Case-insensitive version of mmjson_at |
| `mmjson_get()` | Safely get field values from rows (all or by index) |
| `get_object_value()` | Dict value with default (dict.get wrapper for API compat) |

### Array Utilities

| Function | Description |
|----------|-------------|
| `clean_array()` | Remove null/empty strings, deduplicate, sort |
| `remove_null()` | Filter None values from array |

### Behavior Notes

- Both `mmjson_at()` and `mmjson_at_ic()` skip rows with missing `get_field` for consistent behavior
- `clean_array()` handles mixed types by falling back to string-based sorting

## Test plan

- [x] 43 new unit tests covering all functions
- [x] Edge cases: empty arrays, None values, missing fields, case sensitivity
- [x] All 269 tests passing