### PR TITLE
feat: Add EMDB and IHM pipeline support (Phase 4)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -80,6 +80,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/90/ab4964047dfe1bdbc6c1b878a4462afc52ab917dfbb707fe5bc40bd4569e/ccd2rdmol-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/23/60d1f411e2b5ee0a49b14f89261a8d1e594cfffa2863af00167dddab4ccf/gemmi-0.7.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
@@ -216,6 +217,11 @@ packages:
   purls: []
   size: 209774
   timestamp: 1750239039316
+- pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
+  name: defusedxml
+  version: 0.7.1
+  sha256: a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,6 +30,7 @@ rdkit-postgresql = ">=2024.09.0"
 
 [pypi-dependencies]
 ccd2rdmol = ">=0.2.0"
+defusedxml = ">=0.7.0"
 gemmi = ">=0.7.0"
 typer = ">=0.15.0"
 rich = ">=13.0.0"

--- a/src/mine2/cli.py
+++ b/src/mine2/cli.py
@@ -65,7 +65,7 @@ def update(
     pipelines: Annotated[
         Optional[list[str]],
         typer.Argument(
-            help="Pipelines: pdbj (CIF), pdbj-json (mmJSON), cc, cc-json, ccmodel, ccmodel-json, prd, prd-json, vrpt, contacts, sifts"
+            help="Pipelines: pdbj (CIF), pdbj-json (mmJSON), cc, cc-json, ccmodel, ccmodel-json, prd, prd-json, vrpt, contacts, sifts, emdb (XML), ihm (mmJSON)"
         ),
     ] = None,
     config: Annotated[

--- a/src/mine2/commands/update.py
+++ b/src/mine2/commands/update.py
@@ -24,6 +24,8 @@ AVAILABLE_PIPELINES = [
     "vrpt",
     "contacts",
     "sifts",  # SIFTS cross-references (TTL)
+    "emdb",  # EMDB (XML)
+    "ihm",  # IHM (mmJSON)
 ]
 
 # Legacy aliases for backward compatibility (deprecated)

--- a/src/mine2/pipelines/emdb.py
+++ b/src/mine2/pipelines/emdb.py
@@ -1,0 +1,414 @@
+"""EMDB pipeline - Electron Microscopy Data Bank data loader.
+
+EMDB uses XML data files. The pipeline:
+1. Parses XML files using defusedxml for security
+2. Extracts entry ID from filename (EMD-1234 -> docid 1234)
+3. Stores dates from admin.key_dates in brief_summary
+4. Stores the entire data content as JSONB in brief_summary.content
+"""
+
+import json
+import traceback
+from pathlib import Path
+from typing import Any
+from xml.etree.ElementTree import Element
+
+import defusedxml.ElementTree as ET
+from rich.console import Console
+
+from mine2.config import PipelineConfig, Settings
+from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, bulk_upsert
+from mine2.pipelines.base import BasePipeline, transform_category
+
+console = Console()
+
+
+def _xml_to_dict(element: Element) -> dict[str, Any] | str | list[Any]:
+    """Convert XML element to dictionary recursively.
+
+    Handles:
+    - Elements with children -> dict
+    - Elements with text only -> string
+    - Multiple elements with same tag -> list
+    """
+    result: dict[str, Any] = {}
+
+    # Process child elements
+    for child in element:
+        tag = child.tag
+        child_data = _xml_to_dict(child)
+
+        if tag in result:
+            # Convert to list if multiple elements with same tag
+            if not isinstance(result[tag], list):
+                result[tag] = [result[tag]]
+            result[tag].append(child_data)
+        else:
+            result[tag] = child_data
+
+    # If no children, return text content
+    if not result:
+        text = element.text
+        return text.strip() if text else ""
+
+    # If has both children and text, add text as special key
+    if element.text and element.text.strip():
+        result["_text"] = element.text.strip()
+
+    return result
+
+
+def _get_nested(data: dict[str, Any], *keys: str) -> Any:
+    """Safely get nested dictionary value.
+
+    Args:
+        data: Dictionary to traverse
+        keys: Sequence of keys to follow
+
+    Returns:
+        Value at the nested path, or None if not found
+    """
+    current = data
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+        if current is None:
+            return None
+    return current
+
+
+def _ensure_list(value: Any) -> list[Any]:
+    """Ensure value is a list."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+class EmdbPipeline(BasePipeline):
+    """Pipeline for loading EMDB data from XML files."""
+
+    name = "emdb"
+    file_pattern = "emd-*-v*.xml"
+
+    def extract_entry_id(self, filepath: Path) -> str:
+        """Extract entry ID from filepath.
+
+        Handles filenames like: emd-1234-v1.0.xml -> EMD-1234
+        """
+        name = filepath.name
+        # Remove .xml
+        if name.endswith(".xml"):
+            name = name[:-4]
+        # Extract EMD-1234 part from emd-1234-v1.0
+        parts = name.split("-")
+        if len(parts) >= 2:
+            # parts[0] = 'emd', parts[1] = '1234', rest is version
+            return f"EMD-{parts[1]}".upper()
+        return name.upper()
+
+    def find_jobs(self, limit: int | None = None) -> list[Job]:
+        """Find EMDB XML files."""
+        data_dir = Path(self.config.data)
+
+        if not data_dir.exists():
+            console.print(f"  [red]Data directory not found: {data_dir}[/red]")
+            return []
+
+        jobs = []
+        for filepath in sorted(data_dir.rglob(self.file_pattern)):
+            entry_id = self.extract_entry_id(filepath)
+            jobs.append(
+                Job(
+                    entry_id=entry_id,
+                    filepath=filepath,
+                    extra={},
+                )
+            )
+
+            if limit and len(jobs) >= limit:
+                break
+
+        return jobs
+
+    def process_job(
+        self,
+        job: Job,
+        schema_def: SchemaDef,
+        conninfo: str,
+    ) -> LoaderResult:
+        """Process a single EMDB entry."""
+        try:
+            # Parse XML file
+            tree = ET.parse(str(job.filepath))
+            root = tree.getroot()
+            data_raw = _xml_to_dict(root)
+
+            # Root element always returns a dict
+            if not isinstance(data_raw, dict):
+                raise ValueError(f"Invalid XML structure in {job.filepath}")
+            data: dict[str, Any] = data_raw
+
+            # Transform to row-oriented format for other tables
+            row_data = self._xml_to_row_oriented(data)
+
+            # Transform and load
+            rows_inserted = 0
+
+            # Load brief_summary first
+            brief_rows = self._transform_brief_summary(
+                data, row_data, job.entry_id, schema_def
+            )
+            if brief_rows:
+                # Get brief_summary table definition
+                brief_table = next(
+                    (t for t in schema_def.tables if t.name == "brief_summary"), None
+                )
+                if brief_table:
+                    columns = list(brief_rows[0].keys())
+                    inserted, _ = bulk_upsert(
+                        conninfo,
+                        schema_def.schema_name,
+                        "brief_summary",
+                        columns,
+                        [tuple(r[c] for c in columns) for r in brief_rows],
+                        brief_table.primary_key,
+                    )
+                    rows_inserted += inserted
+
+            # Load other categories
+            for table in schema_def.tables:
+                if table.name == "brief_summary":
+                    continue
+
+                category_rows = self._transform_category(row_data, table, job.entry_id)
+                if category_rows:
+                    columns = list(category_rows[0].keys())
+                    inserted, _ = bulk_upsert(
+                        conninfo,
+                        schema_def.schema_name,
+                        table.name,
+                        columns,
+                        [tuple(r[c] for c in columns) for r in category_rows],
+                        table.primary_key,
+                    )
+                    rows_inserted += inserted
+
+            return LoaderResult(
+                entry_id=job.entry_id,
+                success=True,
+                rows_inserted=rows_inserted,
+            )
+
+        except Exception as e:
+            error_msg = f"{e}\n{traceback.format_exc()}"
+            return LoaderResult(
+                entry_id=job.entry_id,
+                success=False,
+                error=error_msg,
+            )
+
+    def _xml_to_row_oriented(self, data: dict[str, Any]) -> dict[str, list[dict]]:
+        """Convert XML dict structure to row-oriented format.
+
+        EMDB XML has a hierarchical structure that needs to be flattened
+        into category-based row-oriented format for database loading.
+        """
+        result: dict[str, list[dict]] = {}
+
+        # Map XML structure to mmCIF-like categories
+        # The XML structure varies, so we need to handle it flexibly
+
+        # Process admin data
+        admin_data = data.get("admin", {})
+        if admin_data:
+            result["em_admin"] = [self._flatten_dict(admin_data)]
+
+        # Process crossreferences -> database_2, pdbx_database_related
+        crossrefs = data.get("crossreferences", {})
+        if crossrefs:
+            db_refs = _ensure_list(
+                crossrefs.get("pdb_list", {}).get("pdb_reference", [])
+            )
+            if db_refs:
+                result["database_2"] = [
+                    {"database_id": "PDB", "database_code": ref.get("pdb_id", "")}
+                    for ref in db_refs
+                    if isinstance(ref, dict)
+                ]
+
+            emdb_refs = _ensure_list(
+                crossrefs.get("emdb_list", {}).get("emdb_reference", [])
+            )
+            if emdb_refs:
+                result["pdbx_database_related"] = [
+                    {
+                        "db_name": "EMDB",
+                        "db_id": ref.get("emdb_id", ""),
+                        "content_type": ref.get("relationship", ""),
+                    }
+                    for ref in emdb_refs
+                    if isinstance(ref, dict)
+                ]
+
+        # Process sample -> em_entity_assembly, entity, etc.
+        sample = data.get("sample", {})
+        if sample:
+            # Supramolecule
+            supra = sample.get("supramolecule", {})
+            if supra:
+                supra_list = _ensure_list(supra)
+                result["em_entity_assembly"] = [
+                    self._flatten_dict(s) for s in supra_list if isinstance(s, dict)
+                ]
+
+            # Macromolecule
+            macro = sample.get("macromolecule_list", {}).get("macromolecule", [])
+            if macro:
+                macro_list = _ensure_list(macro)
+                result["entity"] = [
+                    self._flatten_dict(m) for m in macro_list if isinstance(m, dict)
+                ]
+
+        # Process structure_determination_list -> em_imaging, em_3d_reconstruction, etc.
+        struct_det = data.get("structure_determination_list", {})
+        if struct_det:
+            det_list = _ensure_list(struct_det.get("structure_determination", []))
+            for det in det_list:
+                if not isinstance(det, dict):
+                    continue
+
+                # Imaging
+                imaging = det.get("microscopy_list", {}).get("microscopy", [])
+                if imaging:
+                    img_list = _ensure_list(imaging)
+                    if "em_imaging" not in result:
+                        result["em_imaging"] = []
+                    result["em_imaging"].extend(
+                        [self._flatten_dict(i) for i in img_list if isinstance(i, dict)]
+                    )
+
+                # Reconstruction
+                recon = det.get("image_processing", [])
+                if recon:
+                    recon_list = _ensure_list(recon)
+                    if "em_3d_reconstruction" not in result:
+                        result["em_3d_reconstruction"] = []
+                    result["em_3d_reconstruction"].extend(
+                        [
+                            self._flatten_dict(r)
+                            for r in recon_list
+                            if isinstance(r, dict)
+                        ]
+                    )
+
+        # Process map -> em_map
+        map_data = data.get("map", {})
+        if map_data:
+            result["em_map"] = [self._flatten_dict(map_data)]
+
+        return result
+
+    def _flatten_dict(self, data: dict[str, Any], prefix: str = "") -> dict[str, Any]:
+        """Flatten nested dict to single level with underscore-joined keys."""
+        result: dict[str, Any] = {}
+        for key, value in data.items():
+            new_key = f"{prefix}_{key}" if prefix else key
+            if isinstance(value, dict):
+                # Check if it's a simple dict with just text
+                if "_text" in value or not value:
+                    result[new_key] = value.get("_text", "")
+                else:
+                    result.update(self._flatten_dict(value, new_key))
+            elif isinstance(value, list):
+                # For lists, take first element if scalar values
+                if value and not isinstance(value[0], (dict, list)):
+                    result[new_key] = value[0] if len(value) == 1 else value
+                elif value and isinstance(value[0], dict):
+                    # Skip nested list of dicts (handled separately)
+                    pass
+            else:
+                result[new_key] = value
+        return result
+
+    def _transform_brief_summary(
+        self,
+        xml_data: dict[str, Any],
+        row_data: dict[str, list[dict]],
+        entry_id: str,
+        schema_def: SchemaDef,
+    ) -> list[dict]:
+        """Transform data to brief_summary format.
+
+        EMDB brief_summary stores:
+        - emdb_id: entry ID (EMD-1234)
+        - docid: integer part (1234)
+        - dates from admin.key_dates
+        - content: entire data as JSONB (excluding brief_summary)
+        - keywords: empty array
+        """
+        # Extract docid from entry_id (EMD-1234 -> 1234)
+        try:
+            docid = int(entry_id.split("-")[1])
+        except (IndexError, ValueError):
+            docid = 0
+
+        # Extract dates from admin.key_dates
+        admin = xml_data.get("admin", {})
+        key_dates = admin.get("key_dates", {})
+
+        deposition_date = key_dates.get("deposition")
+        header_release_date = key_dates.get("header_release")
+        map_release_date = key_dates.get("map_release")
+        modification_date = key_dates.get("update")
+
+        # Handle string or dict with _text
+        def get_date(val: Any) -> str | None:
+            if val is None:
+                return None
+            if isinstance(val, str):
+                return val if val else None
+            if isinstance(val, dict):
+                return val.get("_text")
+            return None
+
+        # Create content as JSONB (entire data except brief_summary)
+        content = {k: v for k, v in row_data.items() if k != "brief_summary"}
+
+        return [
+            {
+                "emdb_id": entry_id,
+                "docid": docid,
+                "deposition_date": get_date(deposition_date),
+                "header_release_date": get_date(header_release_date),
+                "map_release_date": get_date(map_release_date),
+                "modification_date": get_date(modification_date),
+                "update_date": None,
+                "content": json.dumps(content),
+                "keywords": [],
+            }
+        ]
+
+    def _transform_category(
+        self,
+        data: dict[str, list[dict]],
+        table: TableDef,
+        entry_id: str,
+    ) -> list[dict]:
+        """Transform a category's data."""
+        rows = data.get(table.name, [])
+        # Use base transform_category with no column normalization
+        return transform_category(rows, table, entry_id, "emdb_id", None)
+
+
+def run(
+    settings: Settings,
+    config: PipelineConfig,
+    schema_def: SchemaDef,
+    limit: int | None = None,
+) -> list[LoaderResult]:
+    """Run the EMDB pipeline."""
+    pipeline = EmdbPipeline(settings, config, schema_def)
+    return pipeline.run(limit)

--- a/src/mine2/pipelines/ihm.py
+++ b/src/mine2/pipelines/ihm.py
@@ -1,0 +1,719 @@
+"""IHM pipeline - Integrative Hybrid Methods data loader.
+
+IHM pipeline is similar to pdbj but with key differences:
+1. Forces exptl_method to "IHM" (method id 16)
+2. Adds _hash_asym_id_list SHA256 hash for pdbx_struct_assembly_gen
+3. Calculates biological unit molecular weight (bu_mw) for plus_fields
+
+Uses mmJSON input (noatom + plus files) like the pdbj pipeline.
+"""
+
+import hashlib
+import json
+import traceback
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from mine2.config import PipelineConfig, Settings
+from mine2.db.loader import Job, LoaderResult, SchemaDef, TableDef, bulk_upsert
+from mine2.parsers.cif import parse_mmjson_file
+from mine2.parsers.mmjson import (
+    clean_array,
+    merge_data,
+    mmjson_at,
+    mmjson_get,
+    normalize_column_name,
+    remove_null,
+)
+from mine2.pipelines.base import BasePipeline, transform_category
+
+console = Console()
+
+# Chain type mapping for brief_summary
+CHAIN_TYPE_MAPPING = {
+    "polypeptide(D)": 1,
+    "polypeptide(L)": 2,
+    "polydeoxyribonucleotide": 3,
+    "polyribonucleotide": 4,
+    "polysaccharide(D)": 5,
+    "polysaccharide(L)": 6,
+    "polydeoxyribonucleotide/polyribonucleotide hybrid": 7,
+    "cyclic-pseudo-peptide": 8,
+    "other": 9,
+    "peptide nucleic acid": 10,
+}
+
+# Experimental method mapping - IHM is always method 16
+EXPTL_METHOD_MAPPING = {
+    "X-RAY DIFFRACTION": 1,
+    "NEUTRON DIFFRACTION": 2,
+    "FIBER DIFFRACTION": 3,
+    "ELECTRON CRYSTALLOGRAPHY": 4,
+    "ELECTRON MICROSCOPY": 5,
+    "SOLUTION NMR": 6,
+    "SOLID-STATE NMR": 7,
+    "SOLUTION SCATTERING": 8,
+    "POWDER DIFFRACTION": 9,
+    "INFRARED SPECTROSCOPY": 10,
+    "EPR": 11,
+    "FLUORESCENCE TRANSFER": 12,
+    "THEORETICAL MODEL": 13,
+    "HYBRID": 14,
+    "THEORETICAL MODEL (obsolete)": 15,
+    "IHM": 16,
+}
+
+
+def _hex_sha256(text: str) -> str:
+    """Compute SHA256 hex digest of text."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _gen_docid(entry_id: str) -> int:
+    """Generate numeric docid from entry ID.
+
+    PDB IDs are 4-character alphanumeric codes (e.g., "1abc").
+    Convert to numeric using base-36 encoding.
+    """
+    entry_id = entry_id.lower()
+    try:
+        return int(entry_id, 36)
+    except ValueError:
+        return 0
+
+
+def _calculate_mw_for_bu(mmjson: dict[str, Any]) -> float:
+    """Calculate molecular weight for biological unit.
+
+    Follows the original JavaScript implementation to find the preferred
+    biological assembly and calculate its total molecular weight.
+    """
+    # Build assembly info from pdbx_struct_assembly_gen
+    bu_assemblies: dict[str, list[tuple[list[str], list[str]]]] = {}
+
+    pdbx_struct_assembly_gen = mmjson.get("pdbx_struct_assembly_gen", [])
+    for row in pdbx_struct_assembly_gen:
+        assembly_id = row.get("assembly_id")
+        if not assembly_id:
+            continue
+
+        if assembly_id not in bu_assemblies:
+            bu_assemblies[assembly_id] = []
+
+        # Parse operator expression
+        oper_expr = row.get("oper_expression", "")
+        mats = _expand_oper_expression(oper_expr)
+
+        # Parse asym_id_list
+        asym_id_list = row.get("asym_id_list", "")
+        asym_ids = asym_id_list.split(",") if asym_id_list else []
+
+        bu_assemblies[assembly_id].append((mats, asym_ids))
+
+    # Find preferred assembly_id
+    assembly_id = None
+
+    pdbx_struct_assembly = mmjson.get("pdbx_struct_assembly", [])
+    # Try author_and_software first
+    for row in pdbx_struct_assembly:
+        details = row.get("details", "")
+        if details and details.startswith("author_and_software"):
+            assembly_id = row.get("id")
+            break
+
+    # Try author
+    if assembly_id is None:
+        for row in pdbx_struct_assembly:
+            details = row.get("details", "")
+            if details and details.startswith("author"):
+                assembly_id = row.get("id")
+                break
+
+    # Try software
+    if assembly_id is None:
+        for row in pdbx_struct_assembly:
+            details = row.get("details", "")
+            if details and details.startswith("software"):
+                assembly_id = row.get("id")
+                break
+
+    # If still no assembly_id, find largest by sequence length
+    if assembly_id is None:
+        # Build sequence info
+        sinfo: dict[str, int] = {}
+        entity_poly = mmjson.get("entity_poly", [])
+        for row in entity_poly:
+            entity_id = row.get("entity_id")
+            seq = row.get("pdbx_seq_one_letter_code_can", "")
+            if entity_id and seq:
+                sinfo[entity_id] = len(seq.replace("\n", "").replace(" ", ""))
+
+        nor_info: dict[str, int] = {}
+        struct_asym = mmjson.get("struct_asym", [])
+        for row in struct_asym:
+            asym_id = row.get("id")
+            entity_id = row.get("entity_id")
+            if asym_id:
+                nor_info[asym_id] = sinfo.get(entity_id, 0)
+
+        # Find largest assembly
+        largest: tuple[str | None, int] = (None, 0)
+        for aid, assembly_data in bu_assemblies.items():
+            try:
+                int(aid)
+            except ValueError:
+                continue  # Skip non-numeric assembly IDs
+
+            size = 0
+            for mats, asym_ids in assembly_data:
+                nor = sum(nor_info.get(a, 0) for a in asym_ids)
+                size += len(mats) * nor
+
+            if size > largest[1]:
+                largest = (aid, size)
+
+        if largest[0] is not None:
+            assembly_id = largest[0]
+
+    if assembly_id is None:
+        return 0.0
+
+    # Get polymer asym IDs
+    poly_asym_ids: list[str] = []
+    entity_poly = mmjson.get("entity_poly", [])
+    poly_entity_ids = {
+        row.get("entity_id") for row in entity_poly if row.get("entity_id")
+    }
+
+    struct_asym = mmjson.get("struct_asym", [])
+    for row in struct_asym:
+        if row.get("entity_id") in poly_entity_ids:
+            asym_id = row.get("id")
+            if asym_id:
+                poly_asym_ids.append(asym_id)
+
+    # Build asym -> molecular weight mapping
+    asym_to_mw: dict[str, float] = {}
+    entity = mmjson.get("entity", [])
+    entity_mw = {row.get("id"): row.get("formula_weight", 0) for row in entity}
+
+    for row in struct_asym:
+        asym_id = row.get("id")
+        entity_id = row.get("entity_id")
+        if asym_id and entity_id:
+            mw = entity_mw.get(entity_id, 0)
+            asym_to_mw[asym_id] = float(mw) if mw else 0.0
+
+    # Calculate total MW for assembly
+    total_mw = 0.0
+    if assembly_id in bu_assemblies:
+        for mats, asym_ids in bu_assemblies[assembly_id]:
+            asym_mw = sum(asym_to_mw.get(a, 0) for a in asym_ids)
+            total_mw += asym_mw * len(mats)
+
+    return total_mw
+
+
+def _expand_oper_expression(expr: str) -> list[str]:
+    """Expand operator expression like '1-3' or '(1,2)(3,4)' to list of operations."""
+    if not expr:
+        return []
+
+    def expand_range(s: str) -> list[str]:
+        """Expand a single range like '1-3' or '1,2,3'."""
+        result: list[str] = []
+        s = s.replace("(", "").replace(")", "")
+        for part in s.split(","):
+            if "-" in part:
+                try:
+                    start, end = part.split("-")
+                    for i in range(int(start), int(end) + 1):
+                        result.append(str(i))
+                except ValueError:
+                    result.append(part)
+            else:
+                result.append(part.strip())
+        return result
+
+    # Handle product notation like "(1,2)(3,4)"
+    if ")(" in expr:
+        parts = expr.split(")(")
+        left = expand_range(parts[0][1:] if parts[0].startswith("(") else parts[0])
+        right = expand_range(parts[1][:-1] if parts[1].endswith(")") else parts[1])
+        return [f"{left_op}-{right_op}" for left_op in left for right_op in right]
+
+    return expand_range(expr)
+
+
+class IhmPipeline(BasePipeline):
+    """Pipeline for loading IHM structure data."""
+
+    name = "ihm"
+    file_pattern = "*-noatom.json.gz"
+
+    def extract_entry_id(self, filepath: Path) -> str:
+        """Extract entry ID from filepath.
+
+        Handles filenames like: 100d-noatom.json.gz -> 100d
+        """
+        name = filepath.name
+        if name.endswith(".json.gz"):
+            name = name[:-8]
+        if name.endswith("-noatom"):
+            name = name[:-7]
+        return name
+
+    def find_jobs(self, limit: int | None = None) -> list[Job]:
+        """Find mmJSON files and pair with plus data if available."""
+        data_dir = Path(self.config.data)
+        plus_dir = Path(self.config.data_plus) if self.config.data_plus else None
+
+        if not data_dir.exists():
+            console.print(f"  [red]Data directory not found: {data_dir}[/red]")
+            return []
+
+        jobs = []
+        for filepath in sorted(data_dir.rglob(self.file_pattern)):
+            entry_id = self.extract_entry_id(filepath)
+
+            # Look for plus file
+            plus_path = None
+            if plus_dir and plus_dir.exists():
+                candidate = plus_dir.joinpath(f"{entry_id}-plus.json.gz")
+                try:
+                    resolved = candidate.resolve()
+                    if (
+                        resolved.is_relative_to(plus_dir.resolve())
+                        and resolved.exists()
+                    ):
+                        plus_path = candidate
+                except (ValueError, OSError):
+                    pass
+
+            jobs.append(
+                Job(
+                    entry_id=entry_id,
+                    filepath=filepath,
+                    extra={"plus_path": plus_path},
+                )
+            )
+
+            if limit and len(jobs) >= limit:
+                break
+
+        return jobs
+
+    def process_job(
+        self,
+        job: Job,
+        schema_def: SchemaDef,
+        conninfo: str,
+    ) -> LoaderResult:
+        """Process a single IHM entry."""
+        try:
+            # Load main data
+            data = parse_mmjson_file(job.filepath)
+
+            # Merge with plus data if available
+            plus_path = job.extra.get("plus_path")
+            if plus_path:
+                plus_data = parse_mmjson_file(plus_path)
+                data = merge_data(data, plus_data)
+
+            # Add _hash_asym_id_list to pdbx_struct_assembly_gen
+            if "pdbx_struct_assembly_gen" in data:
+                for row in data["pdbx_struct_assembly_gen"]:
+                    asym_id_list = row.get("asym_id_list", "")
+                    row["_hash_asym_id_list"] = _hex_sha256(asym_id_list)
+
+            # Transform and load
+            rows_inserted = 0
+
+            # Get entry table definition
+            entry_table = next(
+                (t for t in schema_def.tables if t.name == "entry"), None
+            )
+            entry_pk = (
+                entry_table.primary_key if entry_table else [schema_def.primary_key]
+            )
+
+            # Load entry table
+            entry_rows = self._transform_entry(data, job.entry_id)
+            if entry_rows:
+                columns = list(entry_rows[0].keys())
+                inserted, _ = bulk_upsert(
+                    conninfo,
+                    schema_def.schema_name,
+                    "entry",
+                    columns,
+                    [tuple(r[c] for c in columns) for r in entry_rows],
+                    entry_pk,
+                )
+                rows_inserted += inserted
+
+            # Load brief_summary
+            brief_rows = self._transform_brief_summary(data, job.entry_id)
+            if brief_rows:
+                brief_table = next(
+                    (t for t in schema_def.tables if t.name == "brief_summary"), None
+                )
+                if brief_table:
+                    columns = list(brief_rows[0].keys())
+                    inserted, _ = bulk_upsert(
+                        conninfo,
+                        schema_def.schema_name,
+                        "brief_summary",
+                        columns,
+                        [tuple(r[c] for c in columns) for r in brief_rows],
+                        brief_table.primary_key,
+                    )
+                    rows_inserted += inserted
+
+            # Load other categories
+            for table in schema_def.tables:
+                if table.name in ("entry", "brief_summary"):
+                    continue
+
+                category_rows = self._transform_category(data, table, job.entry_id)
+                if category_rows:
+                    columns = list(category_rows[0].keys())
+                    inserted, _ = bulk_upsert(
+                        conninfo,
+                        schema_def.schema_name,
+                        table.name,
+                        columns,
+                        [tuple(r[c] for c in columns) for r in category_rows],
+                        table.primary_key,
+                    )
+                    rows_inserted += inserted
+
+            return LoaderResult(
+                entry_id=job.entry_id,
+                success=True,
+                rows_inserted=rows_inserted,
+            )
+
+        except Exception as e:
+            error_msg = f"{e}\n{traceback.format_exc()}"
+            return LoaderResult(
+                entry_id=job.entry_id,
+                success=False,
+                error=error_msg,
+            )
+
+    def _transform_entry(self, data: dict[str, Any], entry_id: str) -> list[dict]:
+        """Transform entry data."""
+        rows = data.get("entry", [])
+        if not rows:
+            return [{"pdbid": entry_id, "id": entry_id.upper()}]
+
+        result = []
+        for row in rows:
+            result.append(
+                {
+                    "pdbid": entry_id,
+                    **{k: v for k, v in row.items() if v is not None},
+                }
+            )
+        return result
+
+    def _transform_brief_summary(
+        self, data: dict[str, Any], entry_id: str
+    ) -> list[dict]:
+        """Transform data to brief_summary format.
+
+        IHM brief_summary is similar to pdbj but:
+        - Forces exptl_method to ["IHM"] with method_id [16]
+        - Includes bu_mw calculation in plus_fields
+        """
+        # Get sequences for various calculations
+        entity_poly = data.get("entity_poly", [])
+        sequences = [
+            row.get("pdbx_seq_one_letter_code_can", "")
+            for row in entity_poly
+            if row.get("pdbx_seq_one_letter_code_can")
+        ]
+
+        # Basic IDs
+        result: dict[str, Any] = {
+            "pdbid": entry_id,
+            "docid": _gen_docid(entry_id),
+        }
+
+        # Dates
+        pdbx_database_status = data.get("pdbx_database_status", [])
+        if pdbx_database_status:
+            result["deposition_date"] = pdbx_database_status[0].get(
+                "recvd_initial_deposition_date"
+            )
+
+        pdbx_audit_revision_history = data.get("pdbx_audit_revision_history", [])
+        if pdbx_audit_revision_history:
+            revision_dates = [
+                row.get("revision_date")
+                for row in pdbx_audit_revision_history
+                if row.get("revision_date")
+            ]
+            if revision_dates:
+                result["release_date"] = revision_dates[0]
+                result["modification_date"] = revision_dates[-1]
+
+        # Authors
+        audit_author = data.get("audit_author", [])
+        if audit_author:
+            result["deposit_author"] = [
+                row.get("name") for row in audit_author if row.get("name")
+            ]
+
+        citation_author = data.get("citation_author", [])
+        if citation_author:
+            result["citation_author"] = [
+                row.get("name") for row in citation_author if row.get("name")
+            ]
+            result["citation_author_pri"] = mmjson_at(
+                citation_author, "name", "citation_id", "primary"
+            )
+
+        # Citations
+        citation = data.get("citation", [])
+        if citation:
+            result["citation_title"] = remove_null(
+                [row.get("title") for row in citation]
+            )
+            result["citation_journal"] = remove_null(
+                [row.get("journal_abbrev") for row in citation]
+            )
+            result["citation_year"] = remove_null([row.get("year") for row in citation])
+            result["citation_volume"] = remove_null(
+                [row.get("journal_volume") for row in citation]
+            )
+
+            result["citation_title_pri"] = mmjson_at(citation, "title", "id", "primary")
+            result["citation_journal_pri"] = mmjson_at(
+                citation, "journal_abbrev", "id", "primary"
+            )
+            result["citation_year_pri"] = mmjson_at(citation, "year", "id", "primary")
+            result["citation_volume_pri"] = mmjson_at(
+                citation, "journal_volume", "id", "primary"
+            )
+
+            # Fallback to first values if no primary
+            if not result.get("citation_title_pri"):
+                result["citation_title_pri"] = (
+                    result["citation_title"][0] if result["citation_title"] else None
+                )
+                result["citation_journal_pri"] = (
+                    result["citation_journal"][0]
+                    if result["citation_journal"]
+                    else None
+                )
+                result["citation_year_pri"] = (
+                    result["citation_year"][0] if result["citation_year"] else None
+                )
+                result["citation_volume_pri"] = (
+                    result["citation_volume"][0] if result["citation_volume"] else None
+                )
+            else:
+                # mmjson_at returns list, get first element
+                result["citation_title_pri"] = (
+                    result["citation_title_pri"][0]
+                    if result["citation_title_pri"]
+                    else None
+                )
+                result["citation_journal_pri"] = (
+                    result["citation_journal_pri"][0]
+                    if result["citation_journal_pri"]
+                    else None
+                )
+                result["citation_year_pri"] = (
+                    result["citation_year_pri"][0]
+                    if result["citation_year_pri"]
+                    else None
+                )
+                result["citation_volume_pri"] = (
+                    result["citation_volume_pri"][0]
+                    if result["citation_volume_pri"]
+                    else None
+                )
+
+            result["db_pubmed"] = [
+                str(row.get("pdbx_database_id_PubMed"))
+                for row in citation
+                if row.get("pdbx_database_id_PubMed")
+            ]
+            result["db_doi"] = remove_null(
+                [row.get("pdbx_database_id_DOI") for row in citation]
+            )
+
+        # Chain info
+        if entity_poly:
+            chain_types = clean_array(
+                [row.get("type") for row in entity_poly if row.get("type")]
+            )
+            result["chain_type"] = chain_types
+            result["chain_type_ids"] = clean_array(
+                [
+                    CHAIN_TYPE_MAPPING.get(t)
+                    for t in chain_types
+                    if t in CHAIN_TYPE_MAPPING
+                ]
+            )
+
+        # Chain count
+        entity = data.get("entity", [])
+        polymer_counts = mmjson_at(
+            entity, "pdbx_number_of_molecules", "type", "polymer"
+        )
+        if polymer_counts:
+            result["chain_number"] = sum(int(c) for c in polymer_counts if c)
+        else:
+            result["chain_number"] = 0
+
+        # Chain lengths
+        result["chain_length"] = [
+            len(seq.replace("\n", "").replace(" ", "")) for seq in sequences
+        ]
+
+        # Descriptor and title
+        if entity:
+            descriptions = [
+                row.get("pdbx_description")
+                for row in entity
+                if row.get("pdbx_description")
+            ]
+            result["pdbx_descriptor"] = ", ".join(clean_array(descriptions))
+
+        struct = data.get("struct", [])
+        if struct:
+            result["struct_title"] = struct[0].get("title")
+
+        # Ligands
+        chem_comp = data.get("chem_comp", [])
+        if chem_comp:
+            # Filter out standard linking types
+            linking_types = {
+                "peptide linking",
+                "L-peptide linking",
+                "DNA linking",
+                "RNA linking",
+            }
+            lig_indices = [
+                i
+                for i, row in enumerate(chem_comp)
+                if row.get("type") not in linking_types
+            ]
+            lig_info: list[str] = []
+            for i in lig_indices:
+                if chem_comp[i].get("name"):
+                    lig_info.append(chem_comp[i]["name"])
+                if chem_comp[i].get("pdbx_synonyms"):
+                    lig_info.append(chem_comp[i]["pdbx_synonyms"])
+                if chem_comp[i].get("id"):
+                    lig_info.append(chem_comp[i]["id"])
+            result["ligand"] = clean_array(lig_info)
+
+        # IHM-specific: always "IHM" method
+        result["exptl_method"] = ["IHM"]
+        result["exptl_method_ids"] = [EXPTL_METHOD_MAPPING["IHM"]]
+
+        # Species info
+        entity_src_gen = data.get("entity_src_gen", [])
+        entity_src_nat = data.get("entity_src_nat", [])
+        pdbx_entity_src_syn = data.get("pdbx_entity_src_syn", [])
+
+        species_parts: list[str] = []
+        species_parts.extend(
+            mmjson_get(entity_src_gen, "pdbx_gene_src_scientific_name") or []
+        )
+        species_parts.extend(mmjson_get(entity_src_gen, "gene_src_common_name") or [])
+        species_parts.extend(mmjson_get(entity_src_nat, "common_name") or [])
+        species_parts.extend(
+            mmjson_get(entity_src_nat, "pdbx_organism_scientific") or []
+        )
+        species_parts.extend(
+            mmjson_get(pdbx_entity_src_syn, "organism_common_name") or []
+        )
+        species_parts.extend(
+            mmjson_get(pdbx_entity_src_syn, "organism_scientific") or []
+        )
+        result["biol_species"] = " ".join(clean_array(species_parts)) or None
+
+        result["host_species"] = mmjson_get(
+            entity_src_gen, "pdbx_host_org_scientific_name", 0
+        )
+
+        # Database references
+        result["db_ec_number"] = clean_array(mmjson_get(entity, "pdbx_ec") or [])
+
+        gene_ontology = data.get("gene_ontology_pdbmlplus", [])
+        result["db_goid"] = clean_array(mmjson_get(gene_ontology, "goid") or [])
+
+        struct_ref = data.get("struct_ref", [])
+        struct_ref_pdbmlplus = data.get("struct_ref_pdbmlplus", [])
+        result["db_uniprot"] = clean_array(
+            mmjson_at(struct_ref, "pdbx_db_accession", "db_name", "UNP")
+            + mmjson_at(
+                struct_ref_pdbmlplus, "pdbx_db_accession", "db_name", "SIFTS_UNP"
+            )
+            + mmjson_at(struct_ref, "db_code", "db_name", "UNP")
+        )
+
+        result["db_genbank"] = clean_array(
+            mmjson_at(struct_ref, "db_code", "db_name", "GB")
+            + mmjson_at(struct_ref, "pdbx_db_accession", "db_name", "GB")
+        )
+        result["db_embl"] = clean_array(
+            mmjson_at(struct_ref, "db_code", "db_name", "EMBL")
+            + mmjson_at(struct_ref, "pdbx_db_accession", "db_name", "EMBL")
+        )
+        result["db_pir"] = clean_array(
+            mmjson_at(struct_ref, "db_code", "db_name", "PIR")
+            + mmjson_at(struct_ref, "pdbx_db_accession", "db_name", "PIR")
+        )
+
+        pdbx_database_related = data.get("pdbx_database_related", [])
+        result["db_emdb"] = clean_array(
+            mmjson_at(pdbx_database_related, "db_id", "db_name", "EMDB")
+        )
+        result["pdb_related"] = clean_array(
+            mmjson_at(pdbx_database_related, "db_id", "db_name", "PDB")
+        )
+
+        # Sequence and keywords
+        result["aaseq"] = "".join(sequences)
+        result["update_date"] = None
+
+        result["db_pfam"] = clean_array(
+            mmjson_at(struct_ref_pdbmlplus, "pdbx_db_accession", "db_name", "Pfam")
+        )
+
+        # Plus fields with bu_mw
+        result["plus_fields"] = json.dumps({"bu_mw": _calculate_mw_for_bu(data)})
+
+        # Keywords - include pdb_XXXXXXXX format for 8-char IDs
+        result["keywords"] = [f"pdb_{entry_id.rjust(8, '0')}"]
+
+        return [result]
+
+    def _transform_category(
+        self,
+        data: dict[str, Any],
+        table: TableDef,
+        entry_id: str,
+    ) -> list[dict]:
+        """Transform a category's data."""
+        rows = data.get(table.name, [])
+        return transform_category(rows, table, entry_id, "pdbid", normalize_column_name)
+
+
+def run(
+    settings: Settings,
+    config: PipelineConfig,
+    schema_def: SchemaDef,
+    limit: int | None = None,
+) -> list[LoaderResult]:
+    """Run the IHM pipeline."""
+    pipeline = IhmPipeline(settings, config, schema_def)
+    return pipeline.run(limit)

--- a/tests/test_emdb.py
+++ b/tests/test_emdb.py
@@ -1,0 +1,395 @@
+"""Tests for EMDB pipeline."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from mine2.config import PipelineConfig, RdbConfig, Settings
+from mine2.db.loader import SchemaDef, TableDef
+from mine2.pipelines.emdb import (
+    EmdbPipeline,
+    _ensure_list,
+    _get_nested,
+)
+
+
+def create_test_emdb_xml_content(entry_id: str, docid: int) -> str:
+    """Create EMDB XML content string.
+
+    Args:
+        entry_id: Entry ID without EMD- prefix (e.g., "1234")
+        docid: Numeric ID (e.g., 1234)
+
+    Returns:
+        XML format string
+    """
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<emd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" emdb_id="EMD-{entry_id}">
+    <admin>
+        <current_status>
+            <code>REL</code>
+        </current_status>
+        <key_dates>
+            <deposition>2020-01-15</deposition>
+            <header_release>2020-03-01</header_release>
+            <map_release>2020-03-01</map_release>
+            <update>2020-06-15</update>
+        </key_dates>
+        <title>Test EMDB Entry {entry_id}</title>
+    </admin>
+    <crossreferences>
+        <pdb_list>
+            <pdb_reference>
+                <pdb_id>1ABC</pdb_id>
+            </pdb_reference>
+        </pdb_list>
+    </crossreferences>
+    <sample>
+        <supramolecule>
+            <id>1</id>
+            <name>Test Supramolecule</name>
+        </supramolecule>
+    </sample>
+    <map>
+        <format>CCP4</format>
+        <size_kb>1024</size_kb>
+    </map>
+</emd>
+"""
+
+
+def create_test_emdb_xml_file(path: Path, entry_id: str, docid: int) -> None:
+    """Create a test EMDB XML file."""
+    content = create_test_emdb_xml_content(entry_id, docid)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def create_test_settings(data_dir: Path) -> Settings:
+    """Create test settings."""
+    return Settings(
+        rdb=RdbConfig(nworkers=2, constring="test"),
+        pipelines={
+            "emdb": PipelineConfig(
+                deffile="schemas/emdb.def.yml",
+                data=str(data_dir),
+            )
+        },
+    )
+
+
+def create_test_schema_def() -> SchemaDef:
+    """Create minimal test schema definition for EMDB."""
+    return SchemaDef(
+        schema_name="emdb",
+        primary_key="emdb_id",
+        tables=[
+            TableDef(
+                name="brief_summary",
+                columns=[
+                    ("emdb_id", "text"),
+                    ("docid", "bigint"),
+                    ("deposition_date", "date"),
+                    ("header_release_date", "date"),
+                    ("map_release_date", "date"),
+                    ("modification_date", "date"),
+                    ("update_date", "timestamp"),
+                    ("content", "jsonb"),
+                    ("keywords", "text[]"),
+                ],
+                primary_key=["emdb_id"],
+            ),
+            TableDef(
+                name="em_admin",
+                columns=[
+                    ("emdb_id", "text"),
+                    ("title", "text"),
+                ],
+                primary_key=["emdb_id"],
+            ),
+        ],
+    )
+
+
+class TestExtractEntryId:
+    """Tests for extract_entry_id method."""
+
+    def test_standard_format(self, tmp_path):
+        """Test standard EMDB filename: emd-1234-v1.0.xml."""
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        filepath = Path("emd-1234-v1.0.xml")
+        assert pipeline.extract_entry_id(filepath) == "EMD-1234"
+
+    def test_version_variations(self, tmp_path):
+        """Test different version formats."""
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        assert pipeline.extract_entry_id(Path("emd-5678-v2.1.xml")) == "EMD-5678"
+        assert pipeline.extract_entry_id(Path("emd-9999-v1.0.xml")) == "EMD-9999"
+
+    def test_lowercase_to_uppercase(self, tmp_path):
+        """Test that entry ID is uppercase."""
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        filepath = Path("emd-1234-v1.0.xml")
+        result = pipeline.extract_entry_id(filepath)
+        assert result == result.upper()
+
+
+class TestFindJobs:
+    """Tests for find_jobs method."""
+
+    def test_find_xml_files(self, tmp_path):
+        """Test finding XML files in directory."""
+        data_dir = tmp_path / "emdb"
+        data_dir.mkdir(parents=True)
+
+        # Create test files
+        create_test_emdb_xml_file(data_dir / "emd-1234-v1.0.xml", "1234", 1234)
+        create_test_emdb_xml_file(data_dir / "emd-5678-v1.0.xml", "5678", 5678)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        jobs = pipeline.find_jobs()
+
+        assert len(jobs) == 2
+        entry_ids = {job.entry_id for job in jobs}
+        assert entry_ids == {"EMD-1234", "EMD-5678"}
+
+    def test_find_with_limit(self, tmp_path):
+        """Test finding files with limit."""
+        data_dir = tmp_path / "emdb"
+        data_dir.mkdir(parents=True)
+
+        # Create multiple test files
+        for i in range(5):
+            create_test_emdb_xml_file(
+                data_dir / f"emd-{1000 + i}-v1.0.xml", str(1000 + i), 1000 + i
+            )
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        jobs = pipeline.find_jobs(limit=2)
+
+        assert len(jobs) == 2
+
+    def test_empty_directory(self, tmp_path):
+        """Test finding files in empty directory."""
+        data_dir = tmp_path / "emdb"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        jobs = pipeline.find_jobs()
+
+        assert len(jobs) == 0
+
+
+class TestXmlParsing:
+    """Tests for XML parsing utilities."""
+
+    def test_ensure_list_with_none(self):
+        """Test _ensure_list with None."""
+        assert _ensure_list(None) == []
+
+    def test_ensure_list_with_value(self):
+        """Test _ensure_list with single value."""
+        assert _ensure_list("test") == ["test"]
+
+    def test_ensure_list_with_list(self):
+        """Test _ensure_list with list."""
+        assert _ensure_list(["a", "b"]) == ["a", "b"]
+
+    def test_get_nested_existing(self):
+        """Test _get_nested with existing path."""
+        data = {"a": {"b": {"c": "value"}}}
+        assert _get_nested(data, "a", "b", "c") == "value"
+
+    def test_get_nested_missing(self):
+        """Test _get_nested with missing path."""
+        data = {"a": {"b": {}}}
+        assert _get_nested(data, "a", "b", "c") is None
+
+    def test_get_nested_partial(self):
+        """Test _get_nested with partial path."""
+        data = {"a": {"b": "not_dict"}}
+        assert _get_nested(data, "a", "b", "c") is None
+
+
+class TestTransformBriefSummary:
+    """Tests for brief_summary transformation."""
+
+    def test_docid_extraction(self, tmp_path):
+        """Test that docid is correctly extracted from entry ID."""
+        data_dir = tmp_path / "emdb"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        xml_data = {
+            "admin": {
+                "key_dates": {
+                    "deposition": "2020-01-15",
+                    "header_release": "2020-03-01",
+                    "map_release": "2020-03-01",
+                    "update": "2020-06-15",
+                }
+            }
+        }
+        row_data = {}
+
+        result = pipeline._transform_brief_summary(
+            xml_data, row_data, "EMD-1234", schema_def
+        )
+
+        assert len(result) == 1
+        assert result[0]["emdb_id"] == "EMD-1234"
+        assert result[0]["docid"] == 1234
+
+    def test_dates_extraction(self, tmp_path):
+        """Test that dates are correctly extracted."""
+        data_dir = tmp_path / "emdb"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        xml_data = {
+            "admin": {
+                "key_dates": {
+                    "deposition": "2020-01-15",
+                    "header_release": "2020-03-01",
+                    "map_release": "2020-03-15",
+                    "update": "2020-06-15",
+                }
+            }
+        }
+        row_data = {}
+
+        result = pipeline._transform_brief_summary(
+            xml_data, row_data, "EMD-1234", schema_def
+        )
+
+        assert result[0]["deposition_date"] == "2020-01-15"
+        assert result[0]["header_release_date"] == "2020-03-01"
+        assert result[0]["map_release_date"] == "2020-03-15"
+        assert result[0]["modification_date"] == "2020-06-15"
+
+    def test_content_as_jsonb(self, tmp_path):
+        """Test that content is stored as JSON string."""
+        data_dir = tmp_path / "emdb"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        xml_data = {"admin": {"key_dates": {}}}
+        row_data = {"em_admin": [{"title": "Test"}]}
+
+        result = pipeline._transform_brief_summary(
+            xml_data, row_data, "EMD-1234", schema_def
+        )
+
+        import json
+
+        content = json.loads(result[0]["content"])
+        assert "em_admin" in content
+        assert content["em_admin"][0]["title"] == "Test"
+
+    def test_keywords_empty(self, tmp_path):
+        """Test that keywords are empty array."""
+        data_dir = tmp_path / "emdb"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        xml_data = {"admin": {"key_dates": {}}}
+        row_data = {}
+
+        result = pipeline._transform_brief_summary(
+            xml_data, row_data, "EMD-1234", schema_def
+        )
+
+        assert result[0]["keywords"] == []
+
+
+class TestProcessJob:
+    """Tests for process_job method."""
+
+    @patch("mine2.pipelines.emdb.bulk_upsert")
+    def test_process_job_success(self, mock_bulk_upsert, tmp_path):
+        """Test successful job processing."""
+        data_dir = tmp_path / "emdb"
+        data_dir.mkdir(parents=True)
+
+        # Create test file
+        xml_file = data_dir / "emd-1234-v1.0.xml"
+        create_test_emdb_xml_file(xml_file, "1234", 1234)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        # Mock bulk_upsert to return success
+        mock_bulk_upsert.return_value = (1, 0)
+
+        from mine2.db.loader import Job
+
+        job = Job(entry_id="EMD-1234", filepath=xml_file, extra={})
+
+        result = pipeline.process_job(job, schema_def, "test_conninfo")
+
+        assert result.success is True
+        assert result.entry_id == "EMD-1234"
+
+    def test_process_job_file_not_found(self, tmp_path):
+        """Test job processing with non-existent file."""
+        data_dir = tmp_path / "emdb"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["emdb"]
+        schema_def = create_test_schema_def()
+        pipeline = EmdbPipeline(settings, config, schema_def)
+
+        from mine2.db.loader import Job
+
+        job = Job(
+            entry_id="EMD-9999",
+            filepath=data_dir / "nonexistent.xml",
+            extra={},
+        )
+
+        result = pipeline.process_job(job, schema_def, "test_conninfo")
+
+        assert result.success is False
+        assert "EMD-9999" in result.entry_id

--- a/tests/test_ihm.py
+++ b/tests/test_ihm.py
@@ -1,0 +1,546 @@
+"""Tests for IHM pipeline."""
+
+import gzip
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from mine2.config import PipelineConfig, RdbConfig, Settings
+from mine2.db.loader import SchemaDef, TableDef
+from mine2.pipelines.ihm import (
+    CHAIN_TYPE_MAPPING,
+    EXPTL_METHOD_MAPPING,
+    IhmPipeline,
+    _calculate_mw_for_bu,
+    _expand_oper_expression,
+    _gen_docid,
+    _hex_sha256,
+)
+
+
+def create_test_ihm_raw_data(entry_id: str) -> dict:
+    """Create raw IHM data dict (without mmJSON wrapper).
+
+    Args:
+        entry_id: Entry ID (e.g., "PDBDEV_00000001")
+
+    Returns:
+        Raw category data dict for direct use with _transform_* methods
+    """
+    return {
+        "entry": [{"id": entry_id.upper()}],
+        "struct": [{"title": f"Test IHM Entry {entry_id}"}],
+        "pdbx_database_status": [{"recvd_initial_deposition_date": "2020-01-15"}],
+        "pdbx_audit_revision_history": [
+            {"revision_date": "2020-03-01", "ordinal": 1},
+            {"revision_date": "2020-06-15", "ordinal": 2},
+        ],
+        "audit_author": [
+            {"name": "Test Author", "pdbx_ordinal": 1},
+        ],
+        "entity": [
+            {
+                "id": "1",
+                "type": "polymer",
+                "pdbx_description": "Test Protein",
+                "pdbx_number_of_molecules": 1,
+            }
+        ],
+        "entity_poly": [
+            {
+                "entity_id": "1",
+                "type": "polypeptide(L)",
+                "pdbx_seq_one_letter_code_can": "MVLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSH",
+            }
+        ],
+        "struct_asym": [
+            {"id": "A", "entity_id": "1"},
+        ],
+        "chem_comp": [
+            {"id": "ALA", "type": "L-peptide linking", "name": "ALANINE"},
+            {
+                "id": "HEM",
+                "type": "non-polymer",
+                "name": "PROTOPORPHYRIN IX CONTAINING FE",
+            },
+        ],
+        "pdbx_struct_assembly": [
+            {"id": "1", "details": "author_defined_assembly"},
+        ],
+        "pdbx_struct_assembly_gen": [
+            {"assembly_id": "1", "oper_expression": "1", "asym_id_list": "A"},
+        ],
+    }
+
+
+def _rows_to_columns(rows: list[dict]) -> dict:
+    """Convert row-oriented data to column-oriented mmJSON format.
+
+    Args:
+        rows: List of row dicts [{"col1": val1, "col2": val2}, ...]
+
+    Returns:
+        Column-oriented dict {"col1": [val1, ...], "col2": [val2, ...]}
+    """
+    if not rows:
+        return {}
+    columns = list(rows[0].keys())
+    return {col: [row.get(col) for row in rows] for col in columns}
+
+
+def create_test_ihm_mmjson_content(entry_id: str) -> dict:
+    """Create IHM mmJSON content dict in column-oriented format.
+
+    Args:
+        entry_id: Entry ID (e.g., "PDBDEV_00000001")
+
+    Returns:
+        mmJSON format dict (column-oriented, wrapped in data_{entry_id} key)
+    """
+    raw_data = create_test_ihm_raw_data(entry_id)
+
+    # Convert each category from row-oriented to column-oriented
+    block_data = {cat: _rows_to_columns(rows) for cat, rows in raw_data.items()}
+
+    # mmJSON format requires data_{entry_id} as top-level key
+    block_name = f"data_{entry_id.upper()}"
+    return {block_name: block_data}
+
+
+def create_test_ihm_mmjson_file(path: Path, entry_id: str) -> None:
+    """Create a test IHM mmJSON file."""
+    content = create_test_ihm_mmjson_content(entry_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if str(path).endswith(".gz"):
+        with gzip.open(path, "wt", encoding="utf-8") as f:
+            json.dump(content, f)
+    else:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(content, f)
+
+
+def create_test_settings(data_dir: Path, plus_dir: Path | None = None) -> Settings:
+    """Create test settings."""
+    config = PipelineConfig(
+        deffile="schemas/ihm.def.yml",
+        data=str(data_dir),
+    )
+    if plus_dir:
+        config.data_plus = str(plus_dir)
+
+    return Settings(
+        rdb=RdbConfig(nworkers=2, constring="test"),
+        pipelines={"ihm": config},
+    )
+
+
+def create_test_schema_def() -> SchemaDef:
+    """Create minimal test schema definition for IHM."""
+    return SchemaDef(
+        schema_name="ihm",
+        primary_key="pdbid",
+        tables=[
+            TableDef(
+                name="entry",
+                columns=[("pdbid", "text"), ("id", "text")],
+                primary_key=["pdbid", "id"],
+            ),
+            TableDef(
+                name="brief_summary",
+                columns=[
+                    ("pdbid", "text"),
+                    ("docid", "bigint"),
+                    ("deposition_date", "date"),
+                    ("release_date", "date"),
+                    ("modification_date", "date"),
+                    ("exptl_method", "text[]"),
+                    ("exptl_method_ids", "integer[]"),
+                    ("struct_title", "text"),
+                    ("plus_fields", "jsonb"),
+                    ("keywords", "text[]"),
+                ],
+                primary_key=["pdbid"],
+            ),
+            TableDef(
+                name="pdbx_struct_assembly_gen",
+                columns=[
+                    ("pdbid", "text"),
+                    ("assembly_id", "text"),
+                    ("asym_id_list", "text"),
+                    ("_hash_asym_id_list", "text"),
+                ],
+                primary_key=["pdbid", "assembly_id"],
+            ),
+        ],
+    )
+
+
+class TestHexSha256:
+    """Tests for _hex_sha256 function."""
+
+    def test_empty_string(self):
+        """Test SHA256 of empty string."""
+        result = _hex_sha256("")
+        assert len(result) == 64  # SHA256 produces 64 hex chars
+        # Known SHA256 of empty string
+        assert (
+            result == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+
+    def test_simple_string(self):
+        """Test SHA256 of simple string."""
+        result = _hex_sha256("A,B,C")
+        assert len(result) == 64
+
+    def test_consistency(self):
+        """Test that same input produces same output."""
+        assert _hex_sha256("test") == _hex_sha256("test")
+
+
+class TestGenDocid:
+    """Tests for _gen_docid function."""
+
+    def test_pdb_style_id(self):
+        """Test with PDB-style 4-character ID."""
+        # 4-char alphanumeric IDs are converted to base-36
+        docid = _gen_docid("1abc")
+        assert isinstance(docid, int)
+        assert docid > 0
+
+    def test_lowercase_conversion(self):
+        """Test that uppercase is handled."""
+        assert _gen_docid("1ABC") == _gen_docid("1abc")
+
+    def test_invalid_id(self):
+        """Test with invalid ID returns 0."""
+        # IDs with invalid characters
+        assert _gen_docid("!!") == 0
+
+
+class TestExpandOperExpression:
+    """Tests for _expand_oper_expression function."""
+
+    def test_single_value(self):
+        """Test single value."""
+        assert _expand_oper_expression("1") == ["1"]
+
+    def test_comma_separated(self):
+        """Test comma-separated values."""
+        assert _expand_oper_expression("1,2,3") == ["1", "2", "3"]
+
+    def test_range(self):
+        """Test range notation."""
+        assert _expand_oper_expression("1-3") == ["1", "2", "3"]
+
+    def test_product_notation(self):
+        """Test product notation like (1,2)(3,4)."""
+        result = _expand_oper_expression("(1,2)(3,4)")
+        assert len(result) == 4
+        assert "1-3" in result
+        assert "1-4" in result
+        assert "2-3" in result
+        assert "2-4" in result
+
+    def test_empty(self):
+        """Test empty expression."""
+        assert _expand_oper_expression("") == []
+
+
+class TestChainTypeMapping:
+    """Tests for chain type mapping."""
+
+    def test_polypeptide_l(self):
+        """Test polypeptide(L) mapping."""
+        assert CHAIN_TYPE_MAPPING["polypeptide(L)"] == 2
+
+    def test_dna(self):
+        """Test DNA mapping."""
+        assert CHAIN_TYPE_MAPPING["polydeoxyribonucleotide"] == 3
+
+    def test_rna(self):
+        """Test RNA mapping."""
+        assert CHAIN_TYPE_MAPPING["polyribonucleotide"] == 4
+
+
+class TestExptlMethodMapping:
+    """Tests for experimental method mapping."""
+
+    def test_ihm_method(self):
+        """Test IHM method is 16."""
+        assert EXPTL_METHOD_MAPPING["IHM"] == 16
+
+    def test_xray(self):
+        """Test X-ray method."""
+        assert EXPTL_METHOD_MAPPING["X-RAY DIFFRACTION"] == 1
+
+
+class TestExtractEntryId:
+    """Tests for extract_entry_id method."""
+
+    def test_standard_format(self, tmp_path):
+        """Test standard filename: entry-noatom.json.gz."""
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        filepath = Path("pdbdev_00000001-noatom.json.gz")
+        assert pipeline.extract_entry_id(filepath) == "pdbdev_00000001"
+
+    def test_without_noatom_suffix(self, tmp_path):
+        """Test filename without -noatom suffix."""
+        settings = create_test_settings(tmp_path)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        # Should still work but not strip suffix
+        filepath = Path("pdbdev_00000001.json.gz")
+        assert pipeline.extract_entry_id(filepath) == "pdbdev_00000001"
+
+
+class TestFindJobs:
+    """Tests for find_jobs method."""
+
+    def test_find_mmjson_files(self, tmp_path):
+        """Test finding mmJSON files in directory."""
+        data_dir = tmp_path / "ihm"
+        data_dir.mkdir(parents=True)
+
+        # Create test files
+        create_test_ihm_mmjson_file(
+            data_dir / "pdbdev_00000001-noatom.json.gz", "pdbdev_00000001"
+        )
+        create_test_ihm_mmjson_file(
+            data_dir / "pdbdev_00000002-noatom.json.gz", "pdbdev_00000002"
+        )
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        jobs = pipeline.find_jobs()
+
+        assert len(jobs) == 2
+        entry_ids = {job.entry_id for job in jobs}
+        assert entry_ids == {"pdbdev_00000001", "pdbdev_00000002"}
+
+    def test_find_with_plus_data(self, tmp_path):
+        """Test finding files with plus data."""
+        data_dir = tmp_path / "ihm"
+        plus_dir = tmp_path / "plus"
+        data_dir.mkdir(parents=True)
+        plus_dir.mkdir(parents=True)
+
+        # Create main file
+        create_test_ihm_mmjson_file(
+            data_dir / "pdbdev_00000001-noatom.json.gz", "pdbdev_00000001"
+        )
+
+        # Create plus file
+        plus_content = {"gene_ontology_pdbmlplus": [{"goid": "GO:0001234"}]}
+        with gzip.open(plus_dir / "pdbdev_00000001-plus.json.gz", "wt") as f:
+            json.dump(plus_content, f)
+
+        settings = create_test_settings(data_dir, plus_dir)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        jobs = pipeline.find_jobs()
+
+        assert len(jobs) == 1
+        assert jobs[0].extra.get("plus_path") is not None
+
+    def test_find_with_limit(self, tmp_path):
+        """Test finding files with limit."""
+        data_dir = tmp_path / "ihm"
+        data_dir.mkdir(parents=True)
+
+        # Create multiple test files
+        for i in range(5):
+            create_test_ihm_mmjson_file(
+                data_dir / f"pdbdev_{i:08d}-noatom.json.gz", f"pdbdev_{i:08d}"
+            )
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        jobs = pipeline.find_jobs(limit=2)
+
+        assert len(jobs) == 2
+
+
+class TestTransformBriefSummary:
+    """Tests for brief_summary transformation."""
+
+    def test_forced_ihm_method(self, tmp_path):
+        """Test that exptl_method is always IHM."""
+        data_dir = tmp_path / "ihm"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        data = create_test_ihm_raw_data("pdbdev_00000001")
+        result = pipeline._transform_brief_summary(data, "pdbdev_00000001")
+
+        assert len(result) == 1
+        assert result[0]["exptl_method"] == ["IHM"]
+        assert result[0]["exptl_method_ids"] == [16]
+
+    def test_plus_fields_bu_mw(self, tmp_path):
+        """Test that plus_fields contains bu_mw."""
+        data_dir = tmp_path / "ihm"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        data = create_test_ihm_raw_data("pdbdev_00000001")
+        result = pipeline._transform_brief_summary(data, "pdbdev_00000001")
+
+        plus_fields = json.loads(result[0]["plus_fields"])
+        assert "bu_mw" in plus_fields
+
+    def test_keywords_format(self, tmp_path):
+        """Test keywords include pdb_XXXXXXXX format."""
+        data_dir = tmp_path / "ihm"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        data = create_test_ihm_raw_data("pdbdev_00000001")
+        result = pipeline._transform_brief_summary(data, "test")
+
+        # Should have pdb_{entry_id} format padded to 8 chars
+        assert any("pdb_" in kw for kw in result[0]["keywords"])
+
+
+class TestHashAsymIdList:
+    """Tests for _hash_asym_id_list computation."""
+
+    @patch("mine2.pipelines.ihm.bulk_upsert")
+    def test_hash_added_to_assembly_gen(self, mock_bulk_upsert, tmp_path):
+        """Test that _hash_asym_id_list is computed."""
+        data_dir = tmp_path / "ihm"
+        data_dir.mkdir(parents=True)
+
+        # Create test file
+        mmjson_file = data_dir / "pdbdev_00000001-noatom.json.gz"
+        create_test_ihm_mmjson_file(mmjson_file, "pdbdev_00000001")
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        # Mock bulk_upsert
+        mock_bulk_upsert.return_value = (1, 0)
+
+        from mine2.db.loader import Job
+
+        job = Job(
+            entry_id="pdbdev_00000001",
+            filepath=mmjson_file,
+            extra={},
+        )
+
+        result = pipeline.process_job(job, schema_def, "test_conninfo")
+
+        # Verify bulk_upsert was called (success means processing worked)
+        assert result.success is True
+
+
+class TestCalculateMwForBu:
+    """Tests for _calculate_mw_for_bu function."""
+
+    def test_empty_data(self):
+        """Test with empty data returns 0."""
+        assert _calculate_mw_for_bu({}) == 0.0
+
+    def test_no_assembly(self):
+        """Test with no assembly data returns 0."""
+        data = {"entity": [{"id": "1", "formula_weight": 1000}]}
+        assert _calculate_mw_for_bu(data) == 0.0
+
+    def test_with_author_assembly(self):
+        """Test with author-defined assembly."""
+        data = {
+            "entity": [{"id": "1", "formula_weight": 10000}],
+            "struct_asym": [{"id": "A", "entity_id": "1"}],
+            "pdbx_struct_assembly": [{"id": "1", "details": "author_defined_assembly"}],
+            "pdbx_struct_assembly_gen": [
+                {"assembly_id": "1", "oper_expression": "1", "asym_id_list": "A"}
+            ],
+        }
+        mw = _calculate_mw_for_bu(data)
+        assert mw == 10000.0
+
+
+class TestProcessJob:
+    """Tests for process_job method."""
+
+    @patch("mine2.pipelines.ihm.bulk_upsert")
+    def test_process_job_success(self, mock_bulk_upsert, tmp_path):
+        """Test successful job processing."""
+        data_dir = tmp_path / "ihm"
+        data_dir.mkdir(parents=True)
+
+        # Create test file
+        mmjson_file = data_dir / "pdbdev_00000001-noatom.json.gz"
+        create_test_ihm_mmjson_file(mmjson_file, "pdbdev_00000001")
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        # Mock bulk_upsert to return success
+        mock_bulk_upsert.return_value = (1, 0)
+
+        from mine2.db.loader import Job
+
+        job = Job(
+            entry_id="pdbdev_00000001",
+            filepath=mmjson_file,
+            extra={},
+        )
+
+        result = pipeline.process_job(job, schema_def, "test_conninfo")
+
+        assert result.success is True
+        assert result.entry_id == "pdbdev_00000001"
+
+    def test_process_job_file_not_found(self, tmp_path):
+        """Test job processing with non-existent file."""
+        data_dir = tmp_path / "ihm"
+        data_dir.mkdir(parents=True)
+
+        settings = create_test_settings(data_dir)
+        config = settings.pipelines["ihm"]
+        schema_def = create_test_schema_def()
+        pipeline = IhmPipeline(settings, config, schema_def)
+
+        from mine2.db.loader import Job
+
+        job = Job(
+            entry_id="pdbdev_99999999",
+            filepath=data_dir / "nonexistent.json.gz",
+            extra={},
+        )
+
+        result = pipeline.process_job(job, schema_def, "test_conninfo")
+
+        assert result.success is False


### PR DESCRIPTION
## Summary
- Implement EMDB pipeline for XML-based Electron Microscopy Data Bank data
- Implement IHM pipeline for Integrative Hybrid Methods (mmJSON) data
- Add comprehensive tests for both pipelines (353 total tests pass)

## Changes
### EMDB Pipeline
- Secure XML parsing with defusedxml
- Extracts dates from `admin.key_dates` structure
- Stores entire XML content as JSONB in `brief_summary.content`
- Entry ID format: `EMD-1234` → docid `1234`

### IHM Pipeline
- Forces `exptl_method` to `["IHM"]` with `method_id [16]`
- Adds `_hash_asym_id_list` SHA256 hash for `pdbx_struct_assembly_gen`
- Calculates molecular weight for biological unit (`bu_mw` in `plus_fields`)
- Supports noatom + plus file merging (same as pdbj pipeline)

### Dependencies
- Added `defusedxml>=0.7.0` for secure XML parsing

## Test plan
- [x] All 353 tests pass
- [x] Type checker passes (existing warnings in other files)
- [x] Linter passes
- [x] EMDB tests: entry ID extraction, job finding, XML parsing, brief_summary transformation
- [x] IHM tests: SHA256 hash, docid generation, oper_expression expansion, chain/method mappings