### PR TITLE
feat: Track pipeline updates with metadata table

### DIFF
--- a/src/mine2/commands/stats.py
+++ b/src/mine2/commands/stats.py
@@ -1,14 +1,14 @@
 """Stats command - show database statistics."""
 
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import datetime
 
 import psycopg
-from psycopg import sql
 from rich.console import Console
 from rich.table import Table
 
 from mine2.config import Settings
+from mine2.db.metadata import get_pipeline_metadata
 
 console = Console()
 
@@ -67,56 +67,9 @@ def _get_row_count(cur: psycopg.Cursor, schema: str) -> int:
 
 
 def _get_last_updated(cur: psycopg.Cursor, schema: str) -> datetime | None:
-    """Get the last update timestamp from brief_summary table if it exists."""
-    # Check if brief_summary table exists
-    cur.execute(
-        """
-        SELECT EXISTS (
-            SELECT 1 FROM information_schema.tables
-            WHERE table_schema = %s AND table_name = 'brief_summary'
-        )
-        """,
-        (schema,),
-    )
-    result = cur.fetchone()
-    if not result or not result[0]:
-        return None
-
-    # Check if modification_date column exists
-    cur.execute(
-        """
-        SELECT EXISTS (
-            SELECT 1 FROM information_schema.columns
-            WHERE table_schema = %s AND table_name = 'brief_summary' AND column_name = 'modification_date'
-        )
-        """,
-        (schema,),
-    )
-    result = cur.fetchone()
-    if not result or not result[0]:
-        return None
-
-    # Get max modification_date
-    cur.execute(
-        sql.SQL("SELECT MAX(modification_date) FROM {}.{}").format(
-            sql.Identifier(schema), sql.Identifier("brief_summary")
-        )
-    )
-    result = cur.fetchone()
-    if result and result[0]:
-        val = result[0]
-        if isinstance(val, datetime):
-            return val
-        # Handle date type (convert to datetime)
-        if isinstance(val, date):
-            return datetime.combine(val, datetime.min.time())
-        # Handle date string
-        if isinstance(val, str):
-            try:
-                return datetime.fromisoformat(val)
-            except ValueError:
-                return None
-    return None
+    """Get the last update timestamp from pipeline_metadata table."""
+    last_updated, _ = get_pipeline_metadata(cur, schema)
+    return last_updated
 
 
 def run_stats(settings: Settings) -> None:

--- a/src/mine2/commands/update.py
+++ b/src/mine2/commands/update.py
@@ -8,6 +8,7 @@ from mine2.commands.utils import resolve_legacy_aliases
 from mine2.config import Settings
 from mine2.db.connection import close_pool, init_pool
 from mine2.db.loader import ensure_schema, load_schema_def
+from mine2.db.metadata import ensure_metadata_table, update_pipeline_metadata
 
 console = Console()
 
@@ -70,6 +71,9 @@ def run_update(
     # Initialize connection pool
     init_pool(settings.rdb.constring, max_size=settings.rdb.get_workers() + 2)
 
+    # Ensure metadata table exists
+    ensure_metadata_table(settings.rdb.constring)
+
     try:
         for pipeline_name in pipelines:
             console.print(f"\n[bold blue]Pipeline: {pipeline_name}[/bold blue]")
@@ -99,7 +103,7 @@ def run_update(
                 runner = getattr(pipeline_module, run_func)
                 # SIFTS pipeline accepts tables parameter
                 if pipeline_name == "sifts" and tables:
-                    runner(
+                    results = runner(
                         settings,
                         pipeline_config,
                         schema_def,
@@ -107,7 +111,17 @@ def run_update(
                         tables=tables,
                     )
                 else:
-                    runner(settings, pipeline_config, schema_def, limit=limit)
+                    results = runner(settings, pipeline_config, schema_def, limit=limit)
+
+                # Update pipeline metadata with timestamp
+                success_count = (
+                    len([r for r in results if r.success]) if results else None
+                )
+                update_pipeline_metadata(
+                    settings.rdb.constring,
+                    schema_def.schema_name,
+                    entries_count=success_count,
+                )
             except ImportError as e:
                 console.print(f"  [red]Pipeline not implemented: {e}[/red]")
             except Exception as e:

--- a/src/mine2/db/metadata.py
+++ b/src/mine2/db/metadata.py
@@ -1,0 +1,91 @@
+"""Pipeline metadata management.
+
+Tracks when each pipeline was last updated.
+"""
+
+from datetime import datetime, timezone
+
+import psycopg
+
+
+def ensure_metadata_table(conninfo: str) -> None:
+    """Create pipeline_metadata table if it doesn't exist.
+
+    Args:
+        conninfo: Database connection string
+    """
+    with psycopg.connect(conninfo) as conn:
+        with conn.cursor() as cur:
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS public.pipeline_metadata (
+                    schema_name TEXT PRIMARY KEY,
+                    last_updated TIMESTAMPTZ NOT NULL,
+                    entries_count INT
+                )
+            """)
+        conn.commit()
+
+
+def update_pipeline_metadata(
+    conninfo: str,
+    schema_name: str,
+    entries_count: int | None = None,
+) -> None:
+    """Update the last_updated timestamp for a pipeline.
+
+    Args:
+        conninfo: Database connection string
+        schema_name: Schema name (e.g., 'pdbj', 'cc')
+        entries_count: Optional count of entries processed
+    """
+    now = datetime.now(timezone.utc)
+
+    with psycopg.connect(conninfo) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO public.pipeline_metadata (schema_name, last_updated, entries_count)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (schema_name) DO UPDATE SET
+                    last_updated = EXCLUDED.last_updated,
+                    entries_count = COALESCE(EXCLUDED.entries_count, pipeline_metadata.entries_count)
+                """,
+                (schema_name, now, entries_count),
+            )
+        conn.commit()
+
+
+def get_pipeline_metadata(
+    cur: psycopg.Cursor,
+    schema_name: str,
+) -> tuple[datetime | None, int | None]:
+    """Get metadata for a pipeline.
+
+    Args:
+        cur: Database cursor
+        schema_name: Schema name
+
+    Returns:
+        Tuple of (last_updated, entries_count)
+    """
+    # Check if table exists
+    cur.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = 'pipeline_metadata'
+        )
+        """
+    )
+    result = cur.fetchone()
+    if not result or not result[0]:
+        return None, None
+
+    cur.execute(
+        "SELECT last_updated, entries_count FROM public.pipeline_metadata WHERE schema_name = %s",
+        (schema_name,),
+    )
+    result = cur.fetchone()
+    if result:
+        return result[0], result[1]
+    return None, None

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,133 @@
+"""Tests for pipeline metadata management."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from mine2.db.metadata import (
+    ensure_metadata_table,
+    get_pipeline_metadata,
+    update_pipeline_metadata,
+)
+
+
+class TestGetPipelineMetadata:
+    """Tests for get_pipeline_metadata function."""
+
+    def test_returns_none_when_table_not_exists(self):
+        """Test returns None when pipeline_metadata table doesn't exist."""
+        cur = MagicMock()
+        # First query: table exists check returns False
+        cur.fetchone.return_value = (False,)
+
+        last_updated, entries_count = get_pipeline_metadata(cur, "pdbj")
+
+        assert last_updated is None
+        assert entries_count is None
+
+    def test_returns_none_when_schema_not_found(self):
+        """Test returns None when schema not in metadata table."""
+        cur = MagicMock()
+        # First query: table exists check returns True
+        # Second query: no row found
+        cur.fetchone.side_effect = [(True,), None]
+
+        last_updated, entries_count = get_pipeline_metadata(cur, "pdbj")
+
+        assert last_updated is None
+        assert entries_count is None
+
+    def test_returns_metadata_when_found(self):
+        """Test returns metadata when schema found."""
+        cur = MagicMock()
+        test_time = datetime(2026, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        # First query: table exists check returns True
+        # Second query: returns metadata
+        cur.fetchone.side_effect = [(True,), (test_time, 100)]
+
+        last_updated, entries_count = get_pipeline_metadata(cur, "pdbj")
+
+        assert last_updated == test_time
+        assert entries_count == 100
+
+
+class TestEnsureMetadataTable:
+    """Tests for ensure_metadata_table function."""
+
+    @patch("mine2.db.metadata.psycopg.connect")
+    def test_creates_table_if_not_exists(self, mock_connect):
+        """Test that CREATE TABLE IF NOT EXISTS is executed."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_connect.return_value.__enter__.return_value = mock_conn
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cur
+
+        ensure_metadata_table("postgresql://test")
+
+        # Verify CREATE TABLE was called
+        mock_cur.execute.assert_called_once()
+        call_args = mock_cur.execute.call_args[0][0]
+        assert "CREATE TABLE IF NOT EXISTS" in call_args
+        assert "pipeline_metadata" in call_args
+        mock_conn.commit.assert_called_once()
+
+    @patch("mine2.db.metadata.psycopg.connect")
+    def test_idempotent_multiple_calls(self, mock_connect):
+        """Test that multiple calls don't fail (IF NOT EXISTS)."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_connect.return_value.__enter__.return_value = mock_conn
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cur
+
+        # Call twice - should not raise
+        ensure_metadata_table("postgresql://test")
+        ensure_metadata_table("postgresql://test")
+
+        assert mock_cur.execute.call_count == 2
+
+
+class TestUpdatePipelineMetadata:
+    """Tests for update_pipeline_metadata function."""
+
+    @patch("mine2.db.metadata.psycopg.connect")
+    def test_inserts_new_record(self, mock_connect):
+        """Test that INSERT with ON CONFLICT is executed."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_connect.return_value.__enter__.return_value = mock_conn
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cur
+
+        update_pipeline_metadata("postgresql://test", "pdbj", entries_count=100)
+
+        mock_cur.execute.assert_called_once()
+        call_args = mock_cur.execute.call_args[0]
+        assert "INSERT INTO" in call_args[0]
+        assert "ON CONFLICT" in call_args[0]
+        assert call_args[1][0] == "pdbj"
+        assert call_args[1][2] == 100
+        mock_conn.commit.assert_called_once()
+
+    @patch("mine2.db.metadata.psycopg.connect")
+    def test_updates_existing_record(self, mock_connect):
+        """Test that upsert updates existing record."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_connect.return_value.__enter__.return_value = mock_conn
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cur
+
+        update_pipeline_metadata("postgresql://test", "pdbj", entries_count=200)
+
+        call_args = mock_cur.execute.call_args[0]
+        assert "DO UPDATE SET" in call_args[0]
+
+    @patch("mine2.db.metadata.psycopg.connect")
+    def test_handles_none_entries_count(self, mock_connect):
+        """Test that None entries_count is handled correctly."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_connect.return_value.__enter__.return_value = mock_conn
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cur
+
+        update_pipeline_metadata("postgresql://test", "cc")
+
+        call_args = mock_cur.execute.call_args[0]
+        assert call_args[1][2] is None  # entries_count should be None


### PR DESCRIPTION
## Summary
- Add `public.pipeline_metadata` table to track when each pipeline was last updated
- Update `stats` command to read from metadata table instead of `brief_summary.modification_date`
- Record timestamp and entry count after each successful pipeline run

## Schema
```sql
CREATE TABLE public.pipeline_metadata (
    schema_name TEXT PRIMARY KEY,
    last_updated TIMESTAMPTZ NOT NULL,
    entries_count INT
);
```

## Test plan
- [x] Unit tests for metadata functions (3 tests pass)
- [ ] Manual test: `pixi run mine2 update pdbj --limit 3` then `pixi run mine2 stats`