### PR TITLE
fix: Fix empty SIFTS tables and remove orphan cc table

### DIFF
--- a/schemas/cc.def.yml
+++ b/schemas/cc.def.yml
@@ -472,21 +472,3 @@ tables:
     keywords:
       - first_instance_model_db_code
     pkout: true
-  - name: link_entry_pdbjplus
-    columns:
-      - - comp_id
-        - text
-      - - db_name
-        - text
-      - - db_accession
-        - text[]
-    primary_key:
-      - comp_id
-      - db_name
-    foreign_keys:
-      - - - comp_id
-        - brief_summary
-        - - comp_id
-    unique_keys: []
-    keywords:
-      - db_name

--- a/src/mine2/pipelines/sifts.py
+++ b/src/mine2/pipelines/sifts.py
@@ -10,6 +10,7 @@ Data format: RDF Turtle (.ttl.gz) files with simple triples.
 """
 
 import gzip
+import logging
 import re
 import traceback
 from pathlib import Path
@@ -33,7 +34,7 @@ TTL_FILES = {
     },
     "pdb_chain_interpro.ttl.gz": {
         "table": "pdb_interpro",
-        "pattern": r"<https://rdf\.wwpdb\.org/pdb/(\w+)/entity/(\d+)> rdfs:seeAlso <http://identifiers\.org/interpro/(IPR\d+)>",
+        "pattern": r"<https://rdf\.wwpdb\.org/pdb/(\w+)/entity/(\d+)> rdfs:seeAlso ipr:(IPR\d+)",
         "columns": ["pdbid", "entity_id", "interpro_id"],
         "pk": ["pdbid", "entity_id", "interpro_id"],
     },
@@ -77,13 +78,13 @@ TTL_FILES = {
     },
     "pdb_chain_cath_uniprot.ttl.gz": {
         "table": "pdb_cath",
-        "pattern": r"<https://rdf\.wwpdb\.org/pdb/(\w+)/entity/(\d+)> rdfs:seeAlso <http://identifiers\.org/cath/([\d\.]+)>",
+        "pattern": r"<https://rdf\.wwpdb\.org/pdb/(\w+)/entity/(\d+)> rdfs:seeAlso cath:(\w+)",
         "columns": ["pdbid", "entity_id", "cath_id"],
         "pk": ["pdbid", "entity_id", "cath_id"],
     },
     "pdb_chain_scop_uniprot.ttl.gz": {
         "table": "pdb_scop",
-        "pattern": r"<https://rdf\.wwpdb\.org/pdb/(\w+)/entity/(\d+)> rdfs:seeAlso <http://identifiers\.org/scop/(\d+)>",
+        "pattern": r"<https://rdf\.wwpdb\.org/pdb/(\w+)/entity/(\d+)> rdfs:seeAlso scop:(\d+)",
         "columns": ["pdbid", "entity_id", "scop_id"],
         "pk": ["pdbid", "entity_id", "scop_id"],
     },
@@ -190,6 +191,7 @@ def run(
     schema_def: SchemaDef,
     limit: int | None = None,
     tables: list[str] | None = None,
+    logger: logging.Logger | None = None,
 ) -> list[LoaderResult]:
     """Run the SIFTS pipeline.
 
@@ -201,10 +203,12 @@ def run(
         schema_def: Database schema definition
         limit: Not used (SIFTS processes all data)
         tables: Optional list of table names to process (default: all)
+        logger: Optional logger for file output
 
     Returns:
         List of LoaderResult for each TTL file processed
     """
+    # SIFTS has its own processing loop, logger is accepted but not heavily used
     results: list[LoaderResult] = []
     data_dir = Path(config.data)
 

--- a/tests/test_sifts.py
+++ b/tests/test_sifts.py
@@ -151,9 +151,10 @@ pdbr:101D dcterms:references pubmed:7711020 .
     def test_parse_interpro(self, tmp_path: Path) -> None:
         """Parse InterPro TTL content."""
         ttl_content = b"""@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ipr: <http://identifiers.org/interpro/> .
 
-<https://rdf.wwpdb.org/pdb/101M/entity/1> rdfs:seeAlso <http://identifiers.org/interpro/IPR000971> .
-<https://rdf.wwpdb.org/pdb/102L/entity/1> rdfs:seeAlso <http://identifiers.org/interpro/IPR002196> .
+<https://rdf.wwpdb.org/pdb/101M/entity/1> rdfs:seeAlso ipr:IPR000971 .
+<https://rdf.wwpdb.org/pdb/102L/entity/1> rdfs:seeAlso ipr:IPR002196 .
 """
         filepath = tmp_path / "test.ttl.gz"
         with gzip.open(filepath, "wb") as f:
@@ -165,6 +166,44 @@ pdbr:101D dcterms:references pubmed:7711020 .
         assert len(results) == 2
         assert results[0] == ("101M", "1", "IPR000971")
         assert results[1] == ("102L", "1", "IPR002196")
+
+    def test_parse_cath(self, tmp_path: Path) -> None:
+        """Parse CATH TTL content."""
+        ttl_content = b"""@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix cath: <http://identifiers.org/cath.domain/> .
+
+<https://rdf.wwpdb.org/pdb/101M/entity/1> rdfs:seeAlso cath:101mA00 .
+<https://rdf.wwpdb.org/pdb/10GS/entity/1> rdfs:seeAlso cath:10gsA01 .
+"""
+        filepath = tmp_path / "test.ttl.gz"
+        with gzip.open(filepath, "wb") as f:
+            f.write(ttl_content)
+
+        pattern = TTL_FILES["pdb_chain_cath_uniprot.ttl.gz"]["pattern"]
+        results = list(parse_ttl_file(filepath, pattern))
+
+        assert len(results) == 2
+        assert results[0] == ("101M", "1", "101mA00")
+        assert results[1] == ("10GS", "1", "10gsA01")
+
+    def test_parse_scop(self, tmp_path: Path) -> None:
+        """Parse SCOP TTL content."""
+        ttl_content = b"""@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix scop: <http://identifiers.org/scop/> .
+
+<https://rdf.wwpdb.org/pdb/2O74/entity/1> rdfs:seeAlso scop:148659 .
+<https://rdf.wwpdb.org/pdb/1H36/entity/1> rdfs:seeAlso scop:90559 .
+"""
+        filepath = tmp_path / "test.ttl.gz"
+        with gzip.open(filepath, "wb") as f:
+            f.write(ttl_content)
+
+        pattern = TTL_FILES["pdb_chain_scop_uniprot.ttl.gz"]["pattern"]
+        results = list(parse_ttl_file(filepath, pattern))
+
+        assert len(results) == 2
+        assert results[0] == ("2O74", "1", "148659")
+        assert results[1] == ("1H36", "1", "90559")
 
     def test_parse_skips_non_matching_lines(self, tmp_path: Path) -> None:
         """Non-matching lines are skipped."""


### PR DESCRIPTION
## Summary

- cc スキーマから誤って定義されていた `link_entry_pdbjplus` テーブルを削除
- SIFTS パイプラインの正規表現パターンを実際の TTL ファイル形式に修正
- CATH/SCOP のテストを追加

## 修正内容

| テーブル | 修正前パターン | 修正後パターン |
|----------|---------------|---------------|
| pdb_interpro | `<http://identifiers.org/interpro/(IPR\d+)>` | `ipr:(IPR\d+)` |
| pdb_cath | `<http://identifiers.org/cath/([\d\.]+)>` | `cath:(\w+)` |
| pdb_scop | `<http://identifiers.org/scop/(\d+)>` | `scop:(\d+)` |

## 結果

| テーブル | 修正前 | 修正後 |
|----------|--------|--------|
| pdb_interpro | 0 行 | 2,067,340 行 |
| pdb_cath | 0 行 | 444,480 行 |
| pdb_scop | 0 行 | 104,570 行 |

## Test plan

- [x] `pixi run pytest tests/test_sifts.py -v` - 22/22 通過
- [x] `pixi run mine2 update sifts` - 全テーブル正常にロード
- [x] `pixi run mine2 update cc --limit 10` - スキーマ変更後も正常動作