### PR TITLE
fix: deduplicate rows by PK in transform_category

### DIFF
--- a/src/mine2/pipelines/base.py
+++ b/src/mine2/pipelines/base.py
@@ -315,6 +315,17 @@ def transform_category(
 
         result.append(transformed_row)
 
+    # Deduplicate by primary key (last occurrence wins, matching upsert semantics).
+    # Some source files contain duplicate rows that violate PK constraints.
+    pk_columns = [c.name for c in table.primary_key.columns]
+    if pk_columns:
+        seen: dict[tuple, int] = {}
+        for i, row in enumerate(result):
+            key = tuple(row.get(c) for c in pk_columns)
+            seen[key] = i
+        if len(seen) < len(result):
+            result = [result[i] for i in sorted(seen.values())]
+
     return result
 
 


### PR DESCRIPTION
## Summary

- Source CIF files may contain duplicate rows (e.g., `3zw1` has 4 identical `pdbx_vrpt_asym` rows for `label_asym_id=E`)
- This causes PK violations in `bulk_copy_entry` (COPY) and `sync_entry_tables` fast-path (INSERT)
- Add PK-based dedup at the end of `transform_category` using last-occurrence-wins semantics (matching upsert behavior)
- Only triggers when actual duplicates are detected, so no overhead for clean data

## Test plan

- [x] `pixi run test -k "not integration"` — all 473 tests pass
- [x] Verified with 3zw1: 12 raw rows → 9 after dedup (3 duplicate `E` rows removed)
- [ ] `pixi run mine2 load vrpt --limit 100 --force` — no PK violations