### PR TITLE
docs: improve pipeline listing in CLI help text

### DIFF
--- a/src/mine2/cli.py
+++ b/src/mine2/cli.py
@@ -103,7 +103,7 @@ def update(
     pipelines: Annotated[
         Optional[list[str]],
         typer.Argument(
-            help="Pipelines: pdbj (CIF), pdbj-json (mmJSON), cc, cc-json, ccmodel, ccmodel-json, prd, prd-json, vrpt, contacts, sifts, emdb (XML), ihm (mmJSON)"
+            help="Pipelines: pdbj, cc, ccmodel, prd, vrpt, contacts, sifts. JSON variants: pdbj-json, cc-json, ccmodel-json, prd-json. Other: emdb (XML), ihm (mmJSON)"
         ),
     ] = None,
     config: Annotated[
@@ -171,7 +171,7 @@ def update(
 def load(
     pipelines: Annotated[
         Optional[list[str]],
-        typer.Argument(help="Pipelines: pdbj, cc, ccmodel, prd"),
+        typer.Argument(help="Pipelines: pdbj, cc, ccmodel, prd, vrpt, contacts, sifts"),
     ] = None,
     config: Annotated[
         Path,


### PR DESCRIPTION
## Summary
- Group pipelines by type in `update` help (main, JSON variants, other)
- List all supported pipelines in `load` help (was missing vrpt, contacts, sifts)

## Test plan
- [x] `mine2 update --help` shows grouped pipeline list
- [x] `mine2 load --help` shows all 7 pipelines