### PR TITLE
fix: update git clone URL to match renamed repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Build a MINE-schema database from PDB data. Synchronizes structural biology data
 ## Installation
 
 ```bash
-git clone https://github.com/N283T/mine2updater-ng.git
-cd mine2updater-ng
+git clone https://github.com/N283T/pdb-mine-builder.git
+cd pdb-mine-builder
 pixi install
 ```
 


### PR DESCRIPTION
## Summary
- Update README.md git clone URL from `mine2updater-ng` to `pdb-mine-builder`

## Test plan
- [x] No remaining `mine2updater-ng` references in codebase