### PR TITLE
docs: add config.example.yml and update configuration docs

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,47 @@
+# pdb-mine-builder configuration
+# Copy this file to config.yml and adjust paths to your environment.
+#
+# Available variables:
+#   ${CWD}      - Current working directory
+#   ${DATA_DIR} - DATA_DIR environment variable (default: /mnt/c/pdb)
+#   ${HOME}     - User home directory
+
+rdb:
+  # Number of worker processes (omit for auto-detect, or override with --workers)
+  # nworkers: 8
+  constring: "host=localhost port=5433 dbname=pmb user=pdbj"
+
+pipelines:
+  # Main PDB structure data (~248k entries)
+  pdbj:
+    format: cif  # "cif" (default) or "mmjson"
+    data: /path/to/data/structures/divided/mmCIF/
+    # data-plus: /path/to/pdbj/pdbjplus/data/pdb/mmjson-plus/
+    # data-nextgen-plus: /path/to/pdbj/pdbjplus/data/pdb_nextgen/mmjson-plus/
+
+  # Chemical component dictionary (single file: components.cif.gz)
+  cc:
+    format: cif
+    data: /path/to/data/monomers/
+
+  # Chemical component models (single file: chem_comp_model.cif.gz)
+  ccmodel:
+    format: cif
+    data: /path/to/data/component-models/complete/complete/
+
+  # BIRD reference dictionary (dual file: prd-all.cif.gz + prdcc-all.cif.gz)
+  prd:
+    format: cif
+    data: /path/to/data/bird/prd/
+
+  # BIRD family data (single file: family-all.cif.gz)
+  prd_family:
+    data: /path/to/data/bird/family/
+
+  # Validation reports (nested directory structure)
+  vrpt:
+    data: /path/to/validation_reports/
+
+  # Protein-protein contact data (JSON array format)
+  contacts:
+    data: /path/to/pdbj/pdbjplus/data/pdb/contacts/

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -8,12 +8,19 @@ pdb-mine-builder uses a YAML configuration file to define database connections a
 
 ## config.yml
 
-Create `config.yml` in the project root (it is gitignored). Here is a full example:
+Copy the example config to get started:
+
+```bash
+cp config.example.yml config.yml
+# Edit config.yml with your data paths
+```
+
+`config.yml` is gitignored. Here is a full example:
 
 ```yaml
 rdb:
   nworkers: 8
-  constring: "dbname='pmb' user='pdbj' port=5433"
+  constring: "host=localhost port=5433 dbname=pmb user=pdbj"
 
 pipelines:
   pdbj:
@@ -29,6 +36,8 @@ pipelines:
   prd:
     format: cif
     data: /data/pdb/bird/prd/
+  prd_family:
+    data: /data/pdb/bird/family/
   vrpt:
     data: /data/pdb/validation_reports/
   contacts:
@@ -91,7 +100,13 @@ When `data-plus` is omitted, only standard structure data is loaded.
 
 ## Variable Expansion
 
-The special variable `${CWD}` expands to the repository root directory. This is useful for test configurations or portable setups:
+Config values support `${VAR}` placeholders that are resolved at load time:
+
+| Variable | Description |
+|----------|-------------|
+| `${CWD}` | Current working directory |
+| `${DATA_DIR}` | `DATA_DIR` environment variable (default: `/mnt/c/pdb`) |
+| `${HOME}` | User home directory |
 
 ```yaml
 pipelines:


### PR DESCRIPTION
## Summary
- Add `config.example.yml` with all pipelines, variable docs, and format options
- Update website configuration docs:
  - Add missing `prd_family` pipeline
  - Document all available variables (`${CWD}`, `${DATA_DIR}`, `${HOME}`)
  - Add `cp config.example.yml config.yml` quick start instruction

## Test plan
- [x] config.example.yml matches config.py schema
- [x] Website docs accurately reflect available options