### PR TITLE
docs: add alternative installation methods to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Move most PyPI dependencies to conda-forge (#82)
-- PostgreSQL version is now managed by rdkit-postgresql dependency (#82)
-
-### Added
-
-- Environment version tests for Python and PostgreSQL (#82)
-
-## [0.2.0] - Unreleased
+## [0.2.0] - 2026-03-07
 
 Initial release as an independent Python project. Rewritten from
 [mine2updater](https://gitlab.com/pdbjapan/mine2updater) (Node.js) by PDBj.
@@ -37,4 +28,8 @@ Initial release as an independent Python project. Rewritten from
 - Pydantic-based configuration with YAML and environment variable support
 - Documentation website with auto-generated schema docs
 - Docker-based test environment (PostgreSQL + RDKit)
+- PyPI publishing support with trusted publishing
+- Environment version tests for Python and PostgreSQL
+- Alternative installation methods (pip, conda+pip)
+- `config.example.yml` with documented options
 - MIT license

--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ This project is based on PDBj's [mine2updater](https://gitlab.com/pdbjapan/mine2
 - RDKit chemical search integration (substructure, similarity)
 - 9 database schemas covering PDB structures, chemical components, validation reports, and more
 
-## Quick Start
+## Installation
+
+### Pixi (recommended)
+
+[Pixi](https://pixi.sh/) manages all dependencies including Python, PostgreSQL, and RDKit in a single environment.
 
 ```bash
 git clone https://github.com/N283T/pdb-mine-builder.git
 cd pdb-mine-builder
 pixi install
-cp .env.example .env   # Edit with your settings
+cp config.example.yml config.yml  # Edit with your data paths
 ```
 
 ```bash
@@ -28,6 +32,28 @@ pixi run db-start      # Start PostgreSQL
 pixi run pmb sync      # Sync data from PDBj
 pixi run pmb load pdbj --force  # Load data
 pixi run pmb stats     # Check database statistics
+```
+
+### pip (alternative)
+
+> **Note**: pip installs the Python package only. You must provide PostgreSQL (17+) and the [RDKit PostgreSQL cartridge](https://github.com/rdkit/rdkit-postgresql) separately. Database management commands (`pixi run db-*`) are not available.
+
+```bash
+pip install pdbminebuilder
+cp config.example.yml config.yml  # Edit with your data paths and connection string
+pmb --help
+```
+
+### conda + pip (alternative)
+
+> **Note**: Database management commands (`pixi run db-*`) are not available. Use your own PostgreSQL instance.
+
+```bash
+conda create -n pmb python=3.12 rdkit-postgresql -c conda-forge
+conda activate pmb
+pip install pdbminebuilder
+cp config.example.yml config.yml
+pmb --help
 ```
 
 See the [Getting Started guide](https://n283t.github.io/pdb-mine-builder/docs/getting-started/installation) for detailed setup instructions.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -6,26 +6,67 @@ sidebar_position: 1
 
 This guide walks you through setting up pdb-mine-builder from scratch.
 
-## Prerequisites
+## Pixi (recommended)
 
-Before you begin, ensure you have the following installed:
+[Pixi](https://pixi.sh/) manages all dependencies — Python, PostgreSQL, RDKit, and CLI tools — in a single isolated environment.
+
+### Prerequisites
 
 | Requirement | Version | Purpose |
 |-------------|---------|---------|
-| Python | 3.12+ | Runtime |
-| PostgreSQL | 17+ | Database (with RDKit extension for chemical searches) |
-| [Pixi](https://pixi.sh/) | Latest | Package manager (manages Python deps and CLI tools) |
+| [Pixi](https://pixi.sh/) | Latest | Package manager |
 | rsync | Any | Data synchronization from PDBj servers |
 
-## Clone and Install
+### Setup
 
 ```bash
 git clone https://github.com/N283T/pdb-mine-builder.git
 cd pdb-mine-builder
 pixi install
+cp config.example.yml config.yml  # Edit with your data paths
 ```
 
-This installs all Python dependencies and CLI tools into an isolated Pixi environment.
+This installs all dependencies including Python, PostgreSQL, and RDKit into an isolated Pixi environment.
+
+## pip (alternative)
+
+:::warning
+pip installs the Python package only. You must provide PostgreSQL (17+) and the [RDKit PostgreSQL cartridge](https://github.com/rdkit/rdkit-postgresql) separately. Database management commands (`pixi run db-*`) are not available — use your own PostgreSQL instance.
+:::
+
+```bash
+pip install pdbminebuilder
+```
+
+Then create a config file and point it to your PostgreSQL instance:
+
+```bash
+curl -O https://raw.githubusercontent.com/N283T/pdb-mine-builder/main/config.example.yml
+cp config.example.yml config.yml  # Edit constring and data paths
+pmb --help
+```
+
+## conda + pip (alternative)
+
+:::warning
+Database management commands (`pixi run db-*`) are not available. Use your own PostgreSQL instance.
+:::
+
+Use conda to install rdkit-postgresql, then pip for the Python package:
+
+```bash
+conda create -n pmb python=3.12 rdkit-postgresql -c conda-forge
+conda activate pmb
+pip install pdbminebuilder
+```
+
+Then create a config file:
+
+```bash
+curl -O https://raw.githubusercontent.com/N283T/pdb-mine-builder/main/config.example.yml
+cp config.example.yml config.yml  # Edit constring and data paths
+pmb --help
+```
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- Add pip and conda+pip installation options to README
- Note limitations: no `pixi run db-*` commands, external PostgreSQL required
- Pixi remains the recommended method

## Test plan
- [x] README renders correctly