### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-03-08
+
 ### Added
 
 - `pmb query` command for executing SQL queries with multi-format output (table, CSV, JSON, Parquet)
 - Read-only connection mode for query command to prevent accidental destructive SQL
 - Polars dependency for DataFrame-based query result handling
+- Docker/Podman support for production deployment
+- Interactive Table Relations page with dynamic Mermaid ER diagrams
+- Schema tab picker with preset examples for quick exploration
+- SVG/PNG diagram download
+- Schema search page with cross-schema column search
+
+### Changed
+
+- Migrated schema docs from .mdx to .md format
+- Extracted shared Schema interface and SCHEMA_PRIORITY to types module
+
+### Fixed
+
+- Schema ordering bug (unknown schemas sorted incorrectly)
+- PNG download silent failures with proper error handling
 
 ## [0.2.0] - 2026-03-07
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdbminebuilder"
-version = "0.2.0"
+version = "0.2.1"
 description = "PDBj data synchronization and database loading tool"
 license = "MIT"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bump version to v0.2.1
- Update CHANGELOG with all changes since v0.2.0

## Changes since v0.2.0

### Added
- `pmb query` command (multi-format output: table/CSV/JSON/Parquet)
- Docker/Podman production deployment support
- Interactive Table Relations page with Mermaid ER diagrams
- Schema search page improvements

### Changed
- Schema docs migrated from .mdx to .md
- Shared types extracted to types module

### Fixed
- Schema ordering bug
- PNG download error handling