### PR TITLE
docs: add database size and entry count statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See the [Getting Started guide](https://n283t.github.io/pdb-mine-builder/docs/ge
 | ccmodel | Chemical component models | ~23k | 8 | 174 MB | CIF / mmJSON |
 | prd | BIRD reference dictionary | ~1.2k | 17 | 50 MB | CIF / mmJSON |
 
-**Total: 368 tables, ~349 GB** with all PDB entries loaded.
+**Total: 368 tables, ~349 GB** with all PDB entries loaded (as of 2026-03-08).
 
 See the [Database Reference](https://n283t.github.io/pdb-mine-builder/docs/database/overview) for schema details and SQL examples.
 

--- a/website/docs/database/overview.md
+++ b/website/docs/database/overview.md
@@ -20,7 +20,7 @@ pdb-mine-builder creates a PostgreSQL database with multiple schemas, each conta
 | [emdb](./emdb.md) | `emdb_id` | — | 79 | — | Electron Microscopy Data Bank (experimental) |
 | [ihm](./ihm.md) | `pdbid` | — | 114 | — | Integrative/Hybrid Methods (experimental) |
 
-**Total: 368 tables, ~349 GB** (excluding emdb/ihm which have no data pipeline yet)
+**Total: 368 tables, ~349 GB** (excluding emdb/ihm which have no data pipeline yet, as of 2026-03-08)
 
 **[Schema Search](/schema-search)** — Search across all schemas, tables, and columns in one place.
 **[Table Relations](/table-relations)** — Explore relationships between tables interactively.


### PR DESCRIPTION
## Summary

- Add entry counts, table counts, and disk size to schema overview and README
- Total: 368 tables, ~349 GB with all PDB entries loaded
- pdbj (183 GB) and vrpt (152 GB) account for 96% of storage

## Test plan
- [ ] Verify overview.md table renders correctly
- [ ] Verify README.md table renders correctly on GitHub