### PR TITLE
docs: update CHANGELOG, README, and website for recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Interactive SQL query examples page with 75 examples across 10 categories (#95)
+- RDKit chemical search examples: substructure, similarity, SMARTS patterns (#97)
+- Configurable sync source URLs for regional wwPDB mirrors (RCSB, PDBe) (#100)
+- `data-dir` config field with priority resolution (config > env > CWD) (#100)
+- `prdcc` config field for explicit PRDCC file path in prd pipeline (#100)
+- PDBj dump file incompatibility warning in migration docs (#98)
+
+### Changed
+
+- Sync URLs updated from `rsync.pdbj.org` to `data.pdbj.org` (#100)
+- Sync targets cc, ccmodel, prd, prd-family now download only required files (#100)
+- Sync destinations derived from pipeline config (single source of truth) (#100)
+- Sync completion message now shows success/failure/skip counts (#100)
+- SQL examples pipeline simplified to use `sqlExamples.json` as single source of truth (#96)
+
+### Removed
+
+- Unused `SyncTarget` class and `sync` field from Settings (#100)
+- PDBj example fetching scripts (`fetch_pdbj_examples.py`, `process_examples.py`, `generate_examples_json.py`) (#96)
+
 ## [0.2.1] - 2026-03-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)
 
-Build a Mine-schema database from PDB data. Synchronizes structural biology data from PDBj (Protein Data Bank Japan) via rsync and loads it into PostgreSQL.
+Build a Mine-schema database from PDB data. Synchronizes structural biology data from wwPDB mirrors (PDBj by default) via rsync and loads it into PostgreSQL.
 
 This project is based on PDBj's [mine2updater](https://gitlab.com/pdbjapan/mine2updater). Thanks to the PDBj team for the original implementation and the [Mine](https://doi.org/10.1093/database/baq021) relational database design.
 
@@ -16,8 +16,10 @@ This project is based on PDBj's [mine2updater](https://gitlab.com/pdbjapan/mine2
 
 - Multi-process parallel data loading with configurable workers
 - Support for multiple data formats (CIF default, mmJSON optional)
+- Configurable sync sources with regional wwPDB mirror support (PDBj, RCSB, PDBe)
 - RDKit chemical search integration (substructure, similarity)
 - SQL query interface with multi-format output (table, CSV, JSON, Parquet)
+- [Interactive SQL examples](https://n283t.github.io/pdb-mine-builder/sql-examples) with 75+ queries across 10 categories
 - 9 database schemas covering PDB structures, chemical components, validation reports, and more
 
 ## Installation
@@ -36,7 +38,7 @@ cp config.example.yml config.yml  # Edit with your data paths
 ```bash
 pixi run db-init       # Initialize PostgreSQL
 pixi run db-start      # Start PostgreSQL
-pixi run pmb sync      # Sync data from PDBj
+pixi run pmb sync      # Sync data from wwPDB (PDBj by default)
 pixi run pmb load pdbj --force  # Load data
 pixi run pmb stats     # Check database statistics
 ```

--- a/website/docs/getting-started/sync.md
+++ b/website/docs/getting-started/sync.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Syncing Data
 
-The `sync` command downloads data from PDBj (Protein Data Bank Japan) servers using rsync.
+The `sync` command downloads data from wwPDB mirrors using rsync. By default, it uses PDBj (Protein Data Bank Japan) servers. Source URLs can be overridden to use regional mirrors (RCSB, PDBe).
 
 ## How It Works
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -40,6 +40,12 @@ function HomepageHeader() {
             to="/table-relations">
             Table Relations
           </Link>
+          <Link
+            className="button button--secondary button--lg"
+            style={{marginLeft: '1rem'}}
+            to="/sql-examples">
+            SQL Examples
+          </Link>
         </div>
       </div>
     </header>
@@ -61,7 +67,7 @@ export default function Home(): ReactNode {
                 <Heading as="h2">Getting Started</Heading>
                 <p>
                   Install pdb-mine-builder, configure your environment,
-                  sync data from PDBj, and load it into PostgreSQL.
+                  sync data from wwPDB mirrors, and load it into PostgreSQL.
                 </p>
                 <Link to="/docs/getting-started/installation">Read the guide →</Link>
               </div>
@@ -76,6 +82,14 @@ export default function Home(): ReactNode {
             </div>
             <div className="row" style={{marginTop: '2rem'}}>
               <div className="col col--6">
+                <Heading as="h2">SQL Examples</Heading>
+                <p>
+                  Browse 75+ ready-to-use SQL queries across 10 categories including
+                  structure search, chemical components, and RDKit similarity search.
+                </p>
+                <Link to="/sql-examples">Browse examples →</Link>
+              </div>
+              <div className="col col--6">
                 <Heading as="h2">Schema Search</Heading>
                 <p>
                   Search across all schemas, tables, and columns in one place.
@@ -83,6 +97,8 @@ export default function Home(): ReactNode {
                 </p>
                 <Link to="/schema-search">Search schemas →</Link>
               </div>
+            </div>
+            <div className="row" style={{marginTop: '2rem'}}>
               <div className="col col--6">
                 <Heading as="h2">Table Relations</Heading>
                 <p>


### PR DESCRIPTION
## Summary
- Add Unreleased section to CHANGELOG covering PRs #95-#100
- Update README: wwPDB mirrors mention, configurable sync sources, SQL examples link
- Add SQL Examples button and section to website homepage
- Update sync docs description for configurable mirrors

## Test plan
- [ ] CHANGELOG entries accurate and complete
- [ ] README links work
- [ ] Website builds successfully