### PR TITLE
fix: remove embedded quotes from vrpt rsync options

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -49,7 +49,7 @@ sync:
   vrpt:
     source: "data.pdbj.org::ftp/validation_reports/"
     dest: ${DATA_DIR}/validation_reports/
-    options: ["-av", "--size-only", '--include="*/"', '--include="*_validation.cif.gz"', '--exclude="*"']
+    options: ["-av", "--size-only", "--include=*/", "--include=*_validation.cif.gz", "--exclude=*"]
 
   # --- mmJSON targets (PDBj-specific) ---
   # pdbj-json:

--- a/website/docs/getting-started/sync.md
+++ b/website/docs/getting-started/sync.md
@@ -98,7 +98,7 @@ sync:
   vrpt:
     source: "data.pdbj.org::ftp/validation_reports/"
     dest: ${DATA_DIR}/validation_reports/
-    options: ["-av", "--size-only", '--include="*/"', '--include="*_validation.cif.gz"', '--exclude="*"']
+    options: ["-av", "--size-only", "--include=*/", "--include=*_validation.cif.gz", "--exclude=*"]
 ```
 
 ## CLI Options


### PR DESCRIPTION
## Summary

- Remove embedded double quotes from vrpt rsync `--include`/`--exclude` options in `config.example.yml` and docs
- `subprocess.run` passes args directly (no shell), so embedded quotes become literal characters, causing the filter to not work (all files downloaded instead of only `*_validation.cif.gz`)

## Test plan

- [x] Verified with `subprocess.run` + `--dry-run` that unquoted options correctly filter to `*_validation.cif.gz` only
- [x] Verified quoted version incorrectly downloads all files (pdf, xml, png, etc.)