### PR TITLE
fix: remove pmb task to fix query quoting issue

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -13,8 +13,7 @@ check = { depends-on = ["lint", "format-check"] }
 format-check = "ruff format --check src/pdbminebuilder"
 test = "pytest tests -v"
 
-# Run (also available as 'pmb' command in pixi shell)
-pmb = "python -m pdbminebuilder"
+# Run: use 'pixi run pmb' (runs entrypoint directly, not as task)
 
 # Database (local development)
 db-init = "initdb -D $PGDATA"


### PR DESCRIPTION
## Summary
- Remove `pmb` task definition from `pixi.toml`
- `pixi run pmb` now executes the `pmb` entrypoint directly instead of going through deno_task_shell
- Fixes single quotes being stripped from SQL query arguments (e.g. `WHERE id = '1a00'`)

## Background
When `pmb` was defined as a pixi task (`pmb = "python -m pdbminebuilder"`), arguments passed via `pixi run pmb query "..."` went through deno_task_shell, which stripped single quotes. Removing the task definition makes `pixi run` find `pmb` as a command in the environment PATH, bypassing the shell layer.

## Test plan
- [x] `pixi run pmb query "SELECT 'hello' AS test"` — single quotes preserved
- [x] `pixi run pmb query "SELECT count(*) FROM pdbj.entry WHERE id LIKE '1a%'"` — LIKE with quotes works
- [x] `pixi run pmb --version` — basic command still works