### PR TITLE
docs: add CLI reference and complete command documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `pmb schema --search <query>` - search column names and comments across all schemas
   - `pmb schema --json` - JSON output for all modes (machine/AI-readable)
   - `pmb schema <name> --json` returns all tables and columns in one response
+- CLI Reference documentation page with all commands
+- Schema inspection guide in Getting Started docs
+- Query command added to Getting Started sidebar
+- RDKit integration section in cc schema documentation
 
 ## [0.2.2] - 2026-03-08
 

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -1,0 +1,144 @@
+---
+sidebar_position: 1
+---
+
+# CLI Reference
+
+Quick reference for all `pmb` commands. See individual pages for detailed usage.
+
+## Data Pipeline Commands
+
+### `pmb sync`
+
+Download data files from PDBj/wwPDB mirrors via rsync. Targets are defined in `config.yml`.
+
+```bash
+pmb sync                    # Sync all configured targets
+pmb sync pdbj cc            # Sync specific targets
+pmb sync --dry-run          # Preview without downloading
+```
+
+See [Syncing Data](./getting-started/sync.md) for details.
+
+### `pmb update`
+
+Run incremental database updates. Tracks file modification times to skip unchanged entries.
+
+```bash
+pmb update                  # Update all pipelines
+pmb update pdbj cc          # Update specific pipelines
+pmb update pdbj --limit 100 # Limit entries processed
+pmb update pdbj --force     # Ignore mtime cache
+```
+
+See [Updating the Database](./getting-started/update.md) for details.
+
+### `pmb load`
+
+Bulk load data using PostgreSQL COPY protocol. **Truncates tables before loading.**
+
+```bash
+pmb load cc --force         # Load single pipeline
+pmb load pdbj --limit 1000 --force  # Load with entry limit
+```
+
+See [Updating the Database - Initial Load](./getting-started/update.md#initial-load-bulk) for details.
+
+### `pmb all`
+
+Run full sync + update cycle in a single step.
+
+```bash
+pmb all
+```
+
+## Query Commands
+
+### `pmb schema`
+
+Inspect database schema definitions from model definitions. No database connection required.
+
+```bash
+pmb schema                  # List all schemas
+pmb schema pdbj             # List tables in schema
+pmb schema pdbj.brief_summary      # Show columns
+pmb schema pdbj.brief_summary.pdbid  # Single column detail
+pmb schema -s resolution    # Search columns
+pmb schema pdbj --json      # JSON output (for AI/scripts)
+```
+
+See [Inspecting Schemas](./getting-started/schema.md) for details.
+
+### `pmb query`
+
+Execute SQL queries with multi-format output.
+
+```bash
+pmb query "SELECT * FROM cc.brief_summary LIMIT 5"
+pmb query -f query.sql -F csv -o out.csv
+pmb query "SELECT * FROM pdbj.brief_summary" -F parquet -o out.parquet
+```
+
+See [Querying the Database](./getting-started/query.md) for details.
+
+### `pmb stats`
+
+Show database statistics (table counts, row counts, sizes).
+
+```bash
+pmb stats
+```
+
+## Administration Commands
+
+### `pmb reset`
+
+Drop and recreate database schemas. **Destructive -- cannot be undone.**
+
+```bash
+pmb reset cc                # Reset single schema
+pmb reset all --force       # Reset all schemas
+```
+
+See [Updating the Database - Reset Schemas](./getting-started/update.md#reset-schemas) for details.
+
+### `pmb setup-rdkit`
+
+Set up RDKit PostgreSQL extension, create `mol` column on `cc.brief_summary`, and load chemical search SQL functions.
+
+```bash
+pmb setup-rdkit
+```
+
+:::note
+This is automatically run by the `cc` pipeline. Use this command only when you need to add RDKit functions to an existing database without re-running the full pipeline.
+:::
+
+See [cc Schema - RDKit Integration](./database/cc.md#rdkit-integration) for details.
+
+### `pmb test`
+
+Create a test database and validate pipelines. Uses `config.test.yml` by default.
+
+```bash
+pmb test                    # Test all pipelines
+pmb test pdbj cc            # Test specific pipelines
+pmb test --drop --limit 20  # Drop existing test DB, process 20 entries
+```
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--drop` | `-d` | Drop existing test database before testing |
+| `--limit` | `-l` | Limit number of files to process (default: 10) |
+| `--workers` | `-w` | Number of worker processes |
+| `--config` | `-c` | Config file path (default: `config.test.yml`) |
+
+## Global Options
+
+These options are available for most commands:
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--config` | `-c` | Config file path (default: `config.yml`) |
+| `--version` | `-v` | Show version |
+| `--help` | | Show help |

--- a/website/docs/database/cc.md
+++ b/website/docs/database/cc.md
@@ -7,6 +7,39 @@ sidebar_position: 2
 - **Primary Key**: `comp_id`
 - **Tables**: 12
 
+## RDKit Integration
+
+The `cc` pipeline automatically sets up [RDKit PostgreSQL Cartridge](https://www.rdkit.org/docs/Cartridge.html) for chemical structure searching. This includes:
+
+1. **RDKit extension** (`CREATE EXTENSION IF NOT EXISTS rdkit`)
+2. **`mol` column** on `cc.brief_summary` -- stores RDKit molecule objects generated from canonical SMILES
+3. **Chemical search SQL functions**:
+   - `similar_compounds(smiles, threshold)` -- Tanimoto similarity search
+   - `substructure_search(smarts)` -- substructure matching
+   - Additional helper functions for chemical queries
+
+To set up RDKit on an existing database without re-running the full `cc` pipeline:
+
+```bash
+pixi run pmb setup-rdkit
+```
+
+:::note
+RDKit requires the `postgresql-rdkit` extension to be installed on the PostgreSQL server. The Docker-based setup includes this by default.
+:::
+
+### Example Queries
+
+```sql
+-- Substructure search: find compounds containing a benzene ring
+SELECT comp_id, name FROM cc.brief_summary WHERE mol @> 'c1ccccc1'::mol;
+
+-- Similarity search: find compounds similar to aspirin (Tanimoto > 0.5)
+SELECT * FROM similar_compounds('CC(=O)Oc1ccccc1C(O)=O', 0.5);
+```
+
+See the [SQL Examples](/sql-examples) page for more chemical search examples.
+
 ## brief_summary
 
 | Column | Type | Description |

--- a/website/docs/getting-started/query.md
+++ b/website/docs/getting-started/query.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 ---
 
 # Querying the Database

--- a/website/docs/getting-started/schema.md
+++ b/website/docs/getting-started/schema.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 6
+---
+
+# Inspecting Schemas
+
+The `pmb schema` command inspects SQLAlchemy model definitions to display schema, table, and column information. **No database connection required** -- all data is read from the model definitions.
+
+## Usage
+
+```bash
+# List all schemas
+pixi run pmb schema
+
+# List tables in a schema
+pixi run pmb schema pdbj
+
+# Show columns in a table
+pixi run pmb schema pdbj.brief_summary
+
+# Show single column detail
+pixi run pmb schema pdbj.brief_summary.pdbid
+```
+
+## Search
+
+Search column names and comments across all schemas:
+
+```bash
+# Search by column name
+pixi run pmb schema -s resolution
+
+# Search by comment text
+pixi run pmb schema -s "deposition date"
+```
+
+## JSON Output
+
+The `--json` flag outputs machine-readable JSON, useful for AI tools and scripts:
+
+```bash
+# All schemas as JSON
+pixi run pmb schema --json
+
+# Full schema with all tables and columns in one response
+pixi run pmb schema pdbj --json
+
+# Table columns as JSON
+pixi run pmb schema pdbj.brief_summary --json
+
+# Search results as JSON
+pixi run pmb schema -s resolution --json
+```
+
+:::tip
+`pmb schema pdbj --json` returns **all tables and columns** in a single JSON response. This is large but ideal for AI agents that need full schema context.
+:::
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--search` | `-s` | Search column names and comments across all schemas |
+| `--json` | | Output in JSON format (machine-readable) |
+| `--config` | `-c` | Config file path (default: `config.yml`) |
+
+## Examples
+
+```bash
+# Find all columns related to resolution
+pixi run pmb schema -s resolution
+
+# Check what columns are in the entity table
+pixi run pmb schema pdbj.entity
+
+# Get full cc schema for AI processing
+pixi run pmb schema cc --json
+
+# Look up a specific column's type and comment
+pixi run pmb schema pdbj.brief_summary.pdbid
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -12,6 +12,16 @@ const sidebars: SidebarsConfig = {
         'getting-started/sync',
         'getting-started/update',
         'getting-started/migration',
+        'getting-started/schema',
+        'getting-started/query',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'CLI Reference',
+      collapsed: true,
+      items: [
+        'cli-reference',
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- Add **CLI Reference** page with quick reference for all 10 `pmb` commands
- Add **Inspecting Schemas** guide to Getting Started (`schema.md`)
- Register `query.md` in sidebar (was orphaned)
- Add **RDKit Integration** section to `cc.md` with `setup-rdkit` documentation
- Update sidebar with CLI Reference category

## Test plan
- [x] Website builds successfully (`npm run build`)
- [ ] Verify sidebar navigation renders correctly
- [ ] Verify all internal links work