### PR TITLE
chore: auto-sync root CHANGELOG.md to website

### DIFF
--- a/scripts/sync_changelog.sh
+++ b/scripts/sync_changelog.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Sync root CHANGELOG.md to website/docs/changelog.md with Docusaurus frontmatter.
+# Called automatically by website prebuild/prestart scripts.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT_DIR/CHANGELOG.md"
+DEST="$ROOT_DIR/website/docs/changelog.md"
+
+if [ ! -f "$SRC" ]; then
+  echo "Error: $SRC not found" >&2
+  exit 1
+fi
+
+{
+  echo "---"
+  echo "sidebar_position: 99"
+  echo "---"
+  echo ""
+  cat "$SRC"
+} > "$DEST"
+
+echo "Synced CHANGELOG.md -> website/docs/changelog.md"

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "prestart": "bash ../scripts/sync_changelog.sh",
     "start": "docusaurus start",
+    "prebuild": "bash ../scripts/sync_changelog.sh",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
## Summary

- Add `scripts/sync_changelog.sh` that copies root `CHANGELOG.md` to `website/docs/changelog.md` with Docusaurus frontmatter
- Add `prebuild` and `prestart` npm hooks to run sync automatically
- Root `CHANGELOG.md` is now the single source of truth -- no more manual dual updates

## Test plan

- [x] `npm run prebuild` syncs correctly
- [x] Content matches root CHANGELOG.md exactly
- [x] `npm run build` passes